### PR TITLE
SCORM: S3 cleaning

### DIFF
--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -46,6 +46,10 @@ try:
     from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 except ImportError:
     pass
+
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.exceptions import ItemNotFoundError
 from .scorm_default import *
 from .fields import DateTime
 from .mixins import ScorableXBlockMixin
@@ -279,29 +283,39 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
     has_author_view = True
 
     def release_all_external_resources(self):
-        """Called when course/chapter/subsection/unit got removed.
+        """Called when course got removed.
         """
-        self.discard_scorm_package(remove_scorm_pkg_root=True)
+        # Delete Draft
+        self.discard_scorm_package(self, remove_scorm_pkg_root=True)
+        # Delete The Published
+        try:
+            self.discard_scorm_package(
+                modulestore().get_item(self.location, revision=ModuleStoreEnum.RevisionOption.published_only),
+                remove_scorm_pkg_root=True
+            )
+        except ItemNotFoundError:
+            logger.info('[INFO] published scorm instance does not exist : location_key : {}'.format(self.location))
 
-    def discard_scorm_package(self, remove_scorm_pkg_root=False, expired_pkg_uuid=None):
-        """Remove old scorm package
+    @staticmethod
+    def discard_scorm_package(xblock, remove_scorm_pkg_root=False, expired_pkg_uuid=None):
+        """Remove scorm packages from draft or published mongodb.
 
-            1) When admin uploading a new scorm package, we specify this argument `remove_scorm_pkg_root` with value `False`.
+            1) When admin uploading a new scorm package, we specify the Flag(`remove_scorm_pkg_root`) with `False`.
             Then the folder `.../block--v1-_edX-.SLV__0001-.2023--10--10-.type_64_scormxblock-.block_64_c8c2f1fe2c9c4fed926b80942aab5a65/fs/NONE.NONE/xxxx_uuid_xxxxx` will be cleared.
 
-            2) When admin remove scorm from `Unit`, we specify this argument `remove_scorm_pkg_root` with value `True`.
-            Then the folder `.../block--v1-_edX-.SLV__0001-.2023--10--10-.type_64_scormxblock-.block_64_c8c2f1fe2c9c4fed926b80942aab5a65` will be removed.
+            2) When admin Remove scorm from `Unit` + Publish this unit, we specify the Flag(`remove_scorm_pkg_root`) with `True`.
+            Then the parent folder `.../block--v1-_edX-.SLV__0001-.2023--10--10-.type_64_scormxblock-.block_64_c8c2f1fe2c9c4fed926b80942aab5a65` will be removed ( `Published` scorm package included inside ).
 
         """
         try:
-            _pkg_uuid = expired_pkg_uuid if expired_pkg_uuid else self.scorm_pkg.split('/')[0]
+            _pkg_uuid = expired_pkg_uuid if expired_pkg_uuid else xblock.scorm_pkg.split('/')[0]
             if not _pkg_uuid:
                 logger.info('[WARN] uuid {} not found in path.'.format(_pkg_uuid))
                 return
 
-            if isinstance(self.fs, OSFS):
+            if isinstance(xblock.fs, OSFS):
                 # Remove : .../block--v1-_edX-.SLV__0001-.2023--10--10-.type_64_scormxblock-.block_64_c8c2f1fe2c9c4fed926b80942aab5a65/fs/NONE.NONE/2b1fe852ed9c4f59b1be5b7636be9f32
-                _pkg_folder_path = self.fs.getsyspath(_pkg_uuid)
+                _pkg_folder_path = xblock.fs.getsyspath(_pkg_uuid)
                 if remove_scorm_pkg_root:
                     _pkg_folder_path = _pkg_folder_path[:_pkg_folder_path.find('/fs/')]
 
@@ -321,19 +335,19 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
             else:
                 deleted_count = 0
                 S3_BUCKET_NAME = settings.DJFS.get('bucket')
-                _s3_prefix = self.fs.dir_path[1:]      # Sample: /xblock/block--v1-_beta-.Content__demo-.2020Q1-.type_64_scormxblock-.block_64_ae63e8b39db84405a8763c9a5441f93c/fs/NONE.NONE
+                _s3_prefix = xblock.fs.dir_path[1:]      # Sample: /xblock/block--v1-_beta-.Content__demo-.2020Q1-.type_64_scormxblock-.block_64_ae63e8b39db84405a8763c9a5441f93c/fs/NONE.NONE
                 _s3_prefix = _s3_prefix if remove_scorm_pkg_root else (_s3_prefix + '/' + _pkg_uuid)
                 _kwargs = {'Bucket': S3_BUCKET_NAME, 'Prefix': _s3_prefix}
                 logger.info('[INFO] Removing AWS S3 Old SCORM Packages by BucketName={}, PREFIX={}...'.format(S3_BUCKET_NAME, _s3_prefix))
 
                 while True:
-                    resp = self.fs.client.list_objects_v2(**_kwargs)
+                    resp = xblock.fs.client.list_objects_v2(**_kwargs)
                     _delete_keys = {
                         'Objects': [
                             {'Key': k if isinstance(k, unicode) else k.decode('utf-8')} for k in [obj['Key'] for obj in resp.get('Contents', [])]
                         ]
                     }
-                    s3_resp = self.fs.client.delete_objects(Bucket=S3_BUCKET_NAME, Delete=_delete_keys)
+                    s3_resp = xblock.fs.client.delete_objects(Bucket=S3_BUCKET_NAME, Delete=_delete_keys)
                     _errors = s3_resp.get('Errors', None)
                     if _errors:
                         raise Exception(_errors)
@@ -362,8 +376,24 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
                 mf = zip_fs.read('imsmanifest.xml')
                 self.scorm_pkg_version, scorm_index, scorm_launch = self._get_scorm_info(mf)
 
+            only_used_in_draft = False
             pkg_id = uuid.uuid4().hex
             expired_pkg_uuid = self.scorm_pkg.split('/')[0]
+
+            try:
+                published_scorm = modulestore().get_item(
+                    self.location, revision=ModuleStoreEnum.RevisionOption.published_only
+                )
+                published_pkg_uuid = published_scorm.scorm_pkg.split('/')[0]
+
+                if published_pkg_uuid != expired_pkg_uuid:
+                    only_used_in_draft = True
+                    logger.info('[INFO] Expired scorm package (uuid={}) only used by draft. So we can remove it.'.format(expired_pkg_uuid))
+                else:
+                    logger.info('[INFO] Scorm package (uuid={}) is being used by the published. So keep it.'.format(expired_pkg_uuid))
+
+            except ItemNotFoundError as e:
+                logger.info('[INFO] Scorm(Published) instance not found : detail : {}'.format(str(e)))
 
             pkg_id = self._upload_scorm_pkg(pkg, pkg_id)
             self.scorm_pkg = os.path.join(pkg_id, scorm_index)
@@ -376,7 +406,8 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
             self.scorm_pkg_filename = pkg.filename
 
             # Remove expired package
-            self.discard_scorm_package(expired_pkg_uuid=expired_pkg_uuid)
+            if only_used_in_draft:
+                self.discard_scorm_package(self, expired_pkg_uuid=expired_pkg_uuid)
 
         if cover_images:
             self.cover_images = [

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -278,22 +278,39 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
     )
     has_author_view = True
 
-    def discard_scorm_package(self):
-        """Remove old scorm package"""
+    def discard_scorm_package(self, remove_dfs_scorm_folder=False):
+        """Remove old scorm package
+
+            1) When admin uploading a new scorm package, we specify this argument `remove_dfs_scorm_folder` with value `False`.
+            Then the folder `.../block--v1-_edX-.SLV__0001-.2023--10--10-.type_64_scormxblock-.block_64_c8c2f1fe2c9c4fed926b80942aab5a65/fs/NONE.NONE/` will be cleared.
+
+            2) When admin remove scorm from `Unit`, we specify this argument `remove_dfs_scorm_folder` with value `True`.
+            Then the folder `.../block--v1-_edX-.SLV__0001-.2023--10--10-.type_64_scormxblock-.block_64_c8c2f1fe2c9c4fed926b80942aab5a65` will be removed.
+
+        """
         try:
             if isinstance(self.fs, OSFS):
                 _pkg_uuid = self.scorm_pkg.split('/')[0]
                 if _pkg_uuid:
+                    # Remove : .../block--v1-_edX-.SLV__0001-.2023--10--10-.type_64_scormxblock-.block_64_c8c2f1fe2c9c4fed926b80942aab5a65/fs/NONE.NONE/2b1fe852ed9c4f59b1be5b7636be9f32
                     _pkg_folder_path = self.fs.getsyspath(_pkg_uuid)
+                    if remove_dfs_scorm_folder:
+                        _pkg_folder_path = _pkg_folder_path[:_pkg_folder_path.find('/fs/')]
+
                     if path_exists(_pkg_folder_path):
                         remove_folder(_pkg_folder_path)
                         logger.info('[INFO] Old SCORM Package Folder {} removed.'.format(_pkg_folder_path))
+
+                        # Remove : .../block--v1-_edX-.SLV__0001-.2023--10--10-.type_64_scormxblock-.block_64_c8c2f1fe2c9c4fed926b80942aab5a65/fs/NONE.NONE/2b1fe852ed9c4f59b1be5b7636be9f32.zip
                         _zip_scorm_package = _pkg_folder_path + '.zip'
                         if path_exists(_zip_scorm_package):
                             remove_file(_zip_scorm_package)
                             logger.info('[INFO] Old SCORM zip package {} removed.'.format(_zip_scorm_package))
+
                     else:
                         logger.warn('[WARN] Old SCORM Package Folder {} not found.'.format(_pkg_folder_path))
+                else:
+                    logger.info('[WARN] uuid not found in path {}.'.format(self.scorm_pkg))
             else:
                 pass
         except Exception as e:

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -278,6 +278,11 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
     )
     has_author_view = True
 
+    def release_all_external_resources(self):
+        """Called when course/chapter/subsection/unit got removed.
+        """
+        self.discard_scorm_package(remove_dfs_scorm_folder=True)
+
     def discard_scorm_package(self, remove_dfs_scorm_folder=False):
         """Remove old scorm package
 

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -318,9 +318,10 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
                     logger.info('[WARN] uuid not found in path {}.'.format(self.scorm_pkg))
 
             else:
-                S3_BUCKET_NAME = settings.DJFS.get('bucket')
                 _s3_prefix = self.fs.dir_path[1:]      # Sample: /xblock/block--v1-_beta-.Content__demo-.2020Q1-.type_64_scormxblock-.block_64_ae63e8b39db84405a8763c9a5441f93c/fs/NONE.NONE
-                _pkg_uuid = self.scorm_pkg.split('/')[0]
+                logger.info('[INFO] Removing AWS S3 Old SCORM Packages by PREFIX={}...'.format(_s3_prefix))
+
+                S3_BUCKET_NAME = settings.DJFS.get('bucket')
                 _delete_keys = {'Objects': []}
                 objects_to_delete = self.fs.client.list_objects_v2(Bucket=S3_BUCKET_NAME, Prefix=_s3_prefix)
                 _delete_keys['Objects'] = [

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -3,10 +3,13 @@ from __future__ import division
 
 import io
 import os
+from os.path import exists as path_exists
+from os import remove as remove_file
 import pkg_resources
 import uuid
 import logging
 import re
+from shutil import rmtree as remove_folder
 from collections import namedtuple
 from lxml import etree
 from urlparse import urlparse
@@ -275,6 +278,28 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
     )
     has_author_view = True
 
+    def discard_scorm_package(self):
+        """Remove old scorm package"""
+        try:
+            if isinstance(self.fs, OSFS):
+                _pkg_uuid = self.scorm_pkg.split('/')[0]
+                if _pkg_uuid:
+                    _pkg_folder_path = self.fs.getsyspath(_pkg_uuid)
+                    if path_exists(_pkg_folder_path):
+                        remove_folder(_pkg_folder_path)
+                        logger.info('[INFO] Old SCORM Package Folder {} removed.'.format(_pkg_folder_path))
+                        _zip_scorm_package = _pkg_folder_path + '.zip'
+                        if path_exists(_zip_scorm_package):
+                            remove_file(_zip_scorm_package)
+                            logger.info('[INFO] Old SCORM zip package {} removed.'.format(_zip_scorm_package))
+                    else:
+                        logger.warn('[WARN] Old SCORM Package Folder {} not found.'.format(_pkg_folder_path))
+            else:
+                pass
+        except Exception as e:
+            logger.error('[ERROR] Got exception while removing folder {} ---> {}'.format(_pkg_folder_path, str(e)))
+            raise
+
     # region Studio handler
     @XBlock.handler
     def studio_upload_files(self, request, suffix=''):
@@ -283,6 +308,8 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
         cover_images = request._request.FILES.getlist('cover_images[]')
 
         if pkg:
+            self.discard_scorm_package()
+
             with ZipFile(pkg.file, 'r') as zip_fs:
                 mf = zip_fs.read('imsmanifest.xml')
                 self.scorm_pkg_version, scorm_index, scorm_launch = self._get_scorm_info(mf)

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -283,7 +283,7 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
         """
         self.discard_scorm_package(remove_scorm_pkg_root=True)
 
-    def discard_scorm_package(self, remove_scorm_pkg_root=False):
+    def discard_scorm_package(self, remove_scorm_pkg_root=False, expired_pkg_uuid=None):
         """Remove old scorm package
 
             1) When admin uploading a new scorm package, we specify this argument `remove_scorm_pkg_root` with value `False`.
@@ -294,34 +294,34 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
 
         """
         try:
+            _pkg_uuid = expired_pkg_uuid if expired_pkg_uuid else self.scorm_pkg.split('/')[0]
+            if not _pkg_uuid:
+                logger.info('[WARN] uuid {} not found in path.'.format(_pkg_uuid))
+                return
+
             if isinstance(self.fs, OSFS):
-                _pkg_uuid = self.scorm_pkg.split('/')[0]
-                if _pkg_uuid:
-                    # Remove : .../block--v1-_edX-.SLV__0001-.2023--10--10-.type_64_scormxblock-.block_64_c8c2f1fe2c9c4fed926b80942aab5a65/fs/NONE.NONE/2b1fe852ed9c4f59b1be5b7636be9f32
-                    _pkg_folder_path = self.fs.getsyspath(_pkg_uuid)
-                    if remove_scorm_pkg_root:
-                        _pkg_folder_path = _pkg_folder_path[:_pkg_folder_path.find('/fs/')]
+                # Remove : .../block--v1-_edX-.SLV__0001-.2023--10--10-.type_64_scormxblock-.block_64_c8c2f1fe2c9c4fed926b80942aab5a65/fs/NONE.NONE/2b1fe852ed9c4f59b1be5b7636be9f32
+                _pkg_folder_path = self.fs.getsyspath(_pkg_uuid)
+                if remove_scorm_pkg_root:
+                    _pkg_folder_path = _pkg_folder_path[:_pkg_folder_path.find('/fs/')]
 
-                    if path_exists(_pkg_folder_path):
-                        remove_folder(_pkg_folder_path)
-                        logger.info('[INFO] Old SCORM Package Folder {} removed.'.format(_pkg_folder_path))
+                if path_exists(_pkg_folder_path):
+                    remove_folder(_pkg_folder_path)
+                    logger.info('[INFO] Old SCORM Package Folder {} removed.'.format(_pkg_folder_path))
 
-                        # Remove : .../block--v1-_edX-.SLV__0001-.2023--10--10-.type_64_scormxblock-.block_64_c8c2f1fe2c9c4fed926b80942aab5a65/fs/NONE.NONE/2b1fe852ed9c4f59b1be5b7636be9f32.zip
-                        _zip_scorm_package = _pkg_folder_path + '.zip'
-                        if path_exists(_zip_scorm_package):
-                            remove_file(_zip_scorm_package)
-                            logger.info('[INFO] Old SCORM zip package {} removed.'.format(_zip_scorm_package))
+                    # Remove : .../block--v1-_edX-.SLV__0001-.2023--10--10-.type_64_scormxblock-.block_64_c8c2f1fe2c9c4fed926b80942aab5a65/fs/NONE.NONE/2b1fe852ed9c4f59b1be5b7636be9f32.zip
+                    _zip_scorm_package = _pkg_folder_path + '.zip'
+                    if path_exists(_zip_scorm_package):
+                        remove_file(_zip_scorm_package)
+                        logger.info('[INFO] Old SCORM zip package {} removed.'.format(_zip_scorm_package))
 
-                    else:
-                        logger.warn('[WARN] Old SCORM Package Folder {} not found.'.format(_pkg_folder_path))
                 else:
-                    logger.info('[WARN] uuid not found in path {}.'.format(self.scorm_pkg))
+                    logger.warn('[WARN] Old SCORM Package Folder {} not found.'.format(_pkg_folder_path))
 
             else:
                 deleted_count = 0
                 S3_BUCKET_NAME = settings.DJFS.get('bucket')
                 _s3_prefix = self.fs.dir_path[1:]      # Sample: /xblock/block--v1-_beta-.Content__demo-.2020Q1-.type_64_scormxblock-.block_64_ae63e8b39db84405a8763c9a5441f93c/fs/NONE.NONE
-                _pkg_uuid = self.scorm_pkg.split('/')[0]
                 _s3_prefix = _s3_prefix if remove_scorm_pkg_root else (_s3_prefix + '/' + _pkg_uuid)
                 _kwargs = {'Bucket': S3_BUCKET_NAME, 'Prefix': _s3_prefix}
                 logger.info('[INFO] Removing AWS S3 Old SCORM Packages by BucketName={}, PREFIX={}...'.format(S3_BUCKET_NAME, _s3_prefix))
@@ -363,6 +363,7 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
                 self.scorm_pkg_version, scorm_index, scorm_launch = self._get_scorm_info(mf)
 
             pkg_id = uuid.uuid4().hex
+            expired_pkg_uuid = self.scorm_pkg.split('/')[0]
 
             pkg_id = self._upload_scorm_pkg(pkg, pkg_id)
             self.scorm_pkg = os.path.join(pkg_id, scorm_index)
@@ -374,7 +375,8 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
             self._upload_scorm_zip(pkg.file, pkg_id)
             self.scorm_pkg_filename = pkg.filename
 
-            self.discard_scorm_package()
+            # Remove expired package
+            self.discard_scorm_package(expired_pkg_uuid=expired_pkg_uuid)
 
         if cover_images:
             self.cover_images = [

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -321,7 +321,7 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
                 S3_BUCKET_NAME = settings.DJFS.get('bucket')
                 _s3_prefix = self.fs.dir_path[1:]      # Sample: /xblock/block--v1-_beta-.Content__demo-.2020Q1-.type_64_scormxblock-.block_64_ae63e8b39db84405a8763c9a5441f93c/fs/NONE.NONE
                 _pkg_uuid = self.scorm_pkg.split('/')[0]
-                _s3_prefix = _s3_prefix if remove_scorm_pkg_root else _s3_prefix + '/' + _pkg_uuid
+                _s3_prefix = _s3_prefix if remove_scorm_pkg_root else (_s3_prefix + '/' + _pkg_uuid)
                 logger.info('[INFO] Removing AWS S3 Old SCORM Packages by BucketName={}, PREFIX={}...'.format(S3_BUCKET_NAME, _s3_prefix))
 
                 _delete_keys = {'Objects': []}

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -358,8 +358,6 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
         cover_images = request._request.FILES.getlist('cover_images[]')
 
         if pkg:
-            self.discard_scorm_package()
-
             with ZipFile(pkg.file, 'r') as zip_fs:
                 mf = zip_fs.read('imsmanifest.xml')
                 self.scorm_pkg_version, scorm_index, scorm_launch = self._get_scorm_info(mf)
@@ -375,6 +373,8 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
             # store SCORM zip file
             self._upload_scorm_zip(pkg.file, pkg_id)
             self.scorm_pkg_filename = pkg.filename
+
+            self.discard_scorm_package()
 
         if cover_images:
             self.cover_images = [

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -316,11 +316,26 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
                         logger.warn('[WARN] Old SCORM Package Folder {} not found.'.format(_pkg_folder_path))
                 else:
                     logger.info('[WARN] uuid not found in path {}.'.format(self.scorm_pkg))
+
             else:
-                pass
+                S3_BUCKET_NAME = settings.DJFS.get('bucket')
+                _s3_prefix = self.fs.dir_path[1:]      # Sample: /xblock/block--v1-_beta-.Content__demo-.2020Q1-.type_64_scormxblock-.block_64_ae63e8b39db84405a8763c9a5441f93c/fs/NONE.NONE
+                _pkg_uuid = self.scorm_pkg.split('/')[0]
+                _delete_keys = {'Objects': []}
+                objects_to_delete = self.fs.client.list_objects_v2(Bucket=S3_BUCKET_NAME, Prefix=_s3_prefix)
+                _delete_keys['Objects'] = [
+                    {'Key': k} for k in [obj['Key'] for obj in objects_to_delete.get('Contents', [])]
+                ]
+
+                s3_resp = self.fs.client.delete_objects(Bucket="MyBucket", Delete=_delete_keys)
+                _errors = s3_resp.get('Errors', None)
+                if _errors:
+                    raise Exception(_errors)
+
+                logger.info('[INFO] {} Old SCORM Packages removed from AWS S3.'.format(len(objects_to_delete.get('Contents', []))))
+
         except Exception as e:
-            logger.error('[ERROR] Got exception while removing folder {} ---> {}'.format(_pkg_folder_path, str(e)))
-            raise
+            logger.error('[ERROR] Got exception while removing package: {}'.format(str(e)))
 
     # region Studio handler
     @XBlock.handler

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -318,24 +318,34 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
                     logger.info('[WARN] uuid not found in path {}.'.format(self.scorm_pkg))
 
             else:
+                deleted_count = 0
                 S3_BUCKET_NAME = settings.DJFS.get('bucket')
                 _s3_prefix = self.fs.dir_path[1:]      # Sample: /xblock/block--v1-_beta-.Content__demo-.2020Q1-.type_64_scormxblock-.block_64_ae63e8b39db84405a8763c9a5441f93c/fs/NONE.NONE
                 _pkg_uuid = self.scorm_pkg.split('/')[0]
                 _s3_prefix = _s3_prefix if remove_scorm_pkg_root else (_s3_prefix + '/' + _pkg_uuid)
+                _kwargs = {'Bucket': S3_BUCKET_NAME, 'Prefix': _s3_prefix}
                 logger.info('[INFO] Removing AWS S3 Old SCORM Packages by BucketName={}, PREFIX={}...'.format(S3_BUCKET_NAME, _s3_prefix))
 
-                _delete_keys = {'Objects': []}
-                objects_to_delete = self.fs.client.list_objects_v2(Bucket=S3_BUCKET_NAME, Prefix=_s3_prefix)
-                _delete_keys['Objects'] = [
-                    {'Key': k} for k in [obj['Key'] for obj in objects_to_delete.get('Contents', [])]
-                ]
+                while True:
+                    resp = self.fs.client.list_objects_v2(**_kwargs)
+                    _delete_keys = {
+                        'Objects': [
+                            {'Key': k if isinstance(k, unicode) else k.decode('utf-8')} for k in [obj['Key'] for obj in resp.get('Contents', [])]
+                        ]
+                    }
+                    s3_resp = self.fs.client.delete_objects(Bucket=S3_BUCKET_NAME, Delete=_delete_keys)
+                    _errors = s3_resp.get('Errors', None)
+                    if _errors:
+                        raise Exception(_errors)
 
-                s3_resp = self.fs.client.delete_objects(Bucket=S3_BUCKET_NAME, Delete=_delete_keys)
-                _errors = s3_resp.get('Errors', None)
-                if _errors:
-                    raise Exception(_errors)
+                    deleted_count += len(_delete_keys['Objects'])
 
-                logger.info('[INFO] {} Old SCORM Packages removed from AWS S3.'.format(len(objects_to_delete.get('Contents', []))))
+                    try:
+                        _kwargs['ContinuationToken'] = resp['NextContinuationToken']
+                    except KeyError:
+                        break
+
+                logger.info('[INFO] {} Old SCORM Packages removed from AWS S3.'.format(deleted_count))
 
         except Exception as e:
             logger.error('[ERROR] Got exception while removing package: {}'.format(str(e)))

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -281,15 +281,15 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
     def release_all_external_resources(self):
         """Called when course/chapter/subsection/unit got removed.
         """
-        self.discard_scorm_package(remove_dfs_scorm_folder=True)
+        self.discard_scorm_package(remove_scorm_pkg_root=True)
 
-    def discard_scorm_package(self, remove_dfs_scorm_folder=False):
+    def discard_scorm_package(self, remove_scorm_pkg_root=False):
         """Remove old scorm package
 
-            1) When admin uploading a new scorm package, we specify this argument `remove_dfs_scorm_folder` with value `False`.
-            Then the folder `.../block--v1-_edX-.SLV__0001-.2023--10--10-.type_64_scormxblock-.block_64_c8c2f1fe2c9c4fed926b80942aab5a65/fs/NONE.NONE/` will be cleared.
+            1) When admin uploading a new scorm package, we specify this argument `remove_scorm_pkg_root` with value `False`.
+            Then the folder `.../block--v1-_edX-.SLV__0001-.2023--10--10-.type_64_scormxblock-.block_64_c8c2f1fe2c9c4fed926b80942aab5a65/fs/NONE.NONE/xxxx_uuid_xxxxx` will be cleared.
 
-            2) When admin remove scorm from `Unit`, we specify this argument `remove_dfs_scorm_folder` with value `True`.
+            2) When admin remove scorm from `Unit`, we specify this argument `remove_scorm_pkg_root` with value `True`.
             Then the folder `.../block--v1-_edX-.SLV__0001-.2023--10--10-.type_64_scormxblock-.block_64_c8c2f1fe2c9c4fed926b80942aab5a65` will be removed.
 
         """
@@ -299,7 +299,7 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
                 if _pkg_uuid:
                     # Remove : .../block--v1-_edX-.SLV__0001-.2023--10--10-.type_64_scormxblock-.block_64_c8c2f1fe2c9c4fed926b80942aab5a65/fs/NONE.NONE/2b1fe852ed9c4f59b1be5b7636be9f32
                     _pkg_folder_path = self.fs.getsyspath(_pkg_uuid)
-                    if remove_dfs_scorm_folder:
+                    if remove_scorm_pkg_root:
                         _pkg_folder_path = _pkg_folder_path[:_pkg_folder_path.find('/fs/')]
 
                     if path_exists(_pkg_folder_path):
@@ -320,6 +320,8 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
             else:
                 S3_BUCKET_NAME = settings.DJFS.get('bucket')
                 _s3_prefix = self.fs.dir_path[1:]      # Sample: /xblock/block--v1-_beta-.Content__demo-.2020Q1-.type_64_scormxblock-.block_64_ae63e8b39db84405a8763c9a5441f93c/fs/NONE.NONE
+                _pkg_uuid = self.scorm_pkg.split('/')[0]
+                _s3_prefix = _s3_prefix if remove_scorm_pkg_root else _s3_prefix + '/' + _pkg_uuid
                 logger.info('[INFO] Removing AWS S3 Old SCORM Packages by BucketName={}, PREFIX={}...'.format(S3_BUCKET_NAME, _s3_prefix))
 
                 _delete_keys = {'Objects': []}

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -328,7 +328,7 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
                     {'Key': k} for k in [obj['Key'] for obj in objects_to_delete.get('Contents', [])]
                 ]
 
-                s3_resp = self.fs.client.delete_objects(Bucket="MyBucket", Delete=_delete_keys)
+                s3_resp = self.fs.client.delete_objects(Bucket=S3_BUCKET_NAME, Delete=_delete_keys)
                 _errors = s3_resp.get('Errors', None)
                 if _errors:
                     raise Exception(_errors)

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -318,10 +318,10 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
                     logger.info('[WARN] uuid not found in path {}.'.format(self.scorm_pkg))
 
             else:
-                _s3_prefix = self.fs.dir_path[1:]      # Sample: /xblock/block--v1-_beta-.Content__demo-.2020Q1-.type_64_scormxblock-.block_64_ae63e8b39db84405a8763c9a5441f93c/fs/NONE.NONE
-                logger.info('[INFO] Removing AWS S3 Old SCORM Packages by PREFIX={}...'.format(_s3_prefix))
-
                 S3_BUCKET_NAME = settings.DJFS.get('bucket')
+                _s3_prefix = self.fs.dir_path[1:]      # Sample: /xblock/block--v1-_beta-.Content__demo-.2020Q1-.type_64_scormxblock-.block_64_ae63e8b39db84405a8763c9a5441f93c/fs/NONE.NONE
+                logger.info('[INFO] Removing AWS S3 Old SCORM Packages by BucketName={}, PREFIX={}...'.format(S3_BUCKET_NAME, _s3_prefix))
+
                 _delete_keys = {'Objects': []}
                 objects_to_delete = self.fs.client.list_objects_v2(Bucket=S3_BUCKET_NAME, Prefix=_s3_prefix)
                 _delete_keys['Objects'] = [


### PR DESCRIPTION
# Task
 - https://foundever.atlassian.net/browse/TRIB-944

# Related PR
 - https://github.com/Learningtribes/platform/pull/1863

# Tested `OSFS` in devstack
 - Before + After uploading new SCORM package from SCORM Editor : 
```
[Before]
root@60ee9c98d568:/edx/app/edxapp/edx-platform# ls -alh  /edx/app/edx_ansible/edx_ansible/docker/plays/cms/static/djpyfs/block--v1-_edX-.SLV__0001-.2023--10--10-.type_64_scormxblock-.block_64_c8c2f1fe2c9c4fed926b80942aab5a65/fs/NONE.NONE/
total 492K
drwxr-xr-x 3 root root 4.0K Jan 15 12:11 .
drwxr-xr-x 3 root root 4.0K Jan 15 09:31 ..
drwxr-xr-x 7 root root 4.0K Jan 15 12:11 2b1fe852ed9c4f59b1be5b7636be9f32
-rw-r--r-- 1 root root 480K Jan 15 12:11 2b1fe852ed9c4f59b1be5b7636be9f32.zip

[After   "2b1fe852ed9c4f59b1be5b7636be9f32" Removed ]
root@60ee9c98d568:/edx/app/edxapp/edx-platform# ls -alh  /edx/app/edx_ansible/edx_ansible/docker/plays/cms/static/djpyfs/block--v1-_edX-.SLV__0001-.2023--10--10-.type_64_scormxblock-.block_64_c8c2f1fe2c9c4fed926b80942aab5a65/fs/NONE.NONE/
total 412K
drwxr-xr-x  3 root root 4.0K Jan 16 01:42 .
drwxr-xr-x  3 root root 4.0K Jan 15 09:31 ..
drwxr-xr-x 11 root root 4.0K Jan 16 01:42 d05651820aa84a9faa66e6b19d06a63d
-rw-r--r--  1 root root 399K Jan 16 01:42 d05651820aa84a9faa66e6b19d06a63d.zip

```

 - After We removed this SCORM XBlock from Course Unit Page : 
```
root@60ee9c98d568:/edx/app/edxapp/edx-platform# ls -alh /edx/app/edx_ansible/edx_ansible/docker/plays/cms/static/djpyfs/block--v1-_edX-.SLV__0001-.2023--10--10-.type_64_scormxblock-.block_64_c8c2f1fe2c9c4fed926b80942aab5a65/fs/NONE.NONE/
ls: cannot access '/edx/app/edx_ansible/edx_ansible/docker/plays/cms/static/djpyfs/block--v1-_edX-.SLV__0001-.2023--10--10-.type_64_scormxblock-.block_64_c8c2f1fe2c9c4fed926b80942aab5a65/fs/NONE.NONE/': No such file or directory
root@60ee9c98d568:/edx/app/edxapp/edx-platform#
```

# Tested in `AWS S3` 
 - Upload a new SCORM Pakcage
```
>>>>>>> Before uploading this New scorm Package, we already old packages on S3 :  

course_id = ''course-v1:griky+123+123'
from django.conf import settings
from xmodule.modulestore.django import modulestore
from opaque_keys.edx.keys import CourseKey
S3_BUCKET_NAME = settings.DJFS.get('bucket')
course_key = CourseKey.from_string(course_id)
_course = modulestore().get_course(course_key)
scs = [_scorm_block for _scorm_block in modulestore().get_items(_course.id, qualifiers={'category': 'scormxblock'})]
_s3_prefix = scs[0].fs.dir_path[1:]
objects_to_delete = scs[0].fs.client.list_objects_v2(Bucket=S3_BUCKET_NAME, Prefix=_s3_prefix)
In [16]: len(objects_to_delete.get('Contents', []))
Out[16]: 137

>>>>>>> After uploading this New scorm Package, old package replaced with new on S3 :
objects_to_delete = scs[0].fs.client.list_objects_v2(Bucket=S3_BUCKET_NAME, Prefix=_s3_prefix)
In [18]: len(objects_to_delete.get('Contents', []))
Out[18]: 188
 
>>>>>>> Upload Old the scorm package again 
objects_to_delete = scs[0].fs.client.list_objects_v2(Bucket=S3_BUCKET_NAME, Prefix=_s3_prefix)
In [21]: len(objects_to_delete.get('Contents', []))
Out[21]: 137
```

![image](https://github.com/Learningtribes/edx_xblock_scorm/assets/26813045/baae10cf-4766-4495-8f94-8aef8958c899)


 - Query SCORM packages on S3 again after deleting this Courseware 
```
objects_to_delete = scs[0].fs.client.list_objects_v2(Bucket=S3_BUCKET_NAME, Prefix=_s3_prefix)
In [23]: len(objects_to_delete.get('Contents', []))
Out[23]: 0
```

