### PR TITLE
remove 'due' field from editable_fields list

### DIFF
--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -272,7 +272,7 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
     )
 
     editable_fields = (
-        'scorm_pkg', 'scorm_pkg_filename', 'display_name', 'due',
+        'scorm_pkg', 'scorm_pkg_filename', 'display_name',
         'has_score', 'weight', 'scorm_allow_rescore',
         'open_new_tab', 'instruction', 'cover_image'
     )


### PR DESCRIPTION
[Jira card](https://foundever.atlassian.net/jira/software/projects/TRIB/boards/152?assignee=63ceee7e0d930a766df00c51&selectedIssue=TRIB-1457)

## Purpose
SCORM: Remove the field "Due date"

## Approach
Removing `due` field from `editable_fields` list.

![image](https://github.com/user-attachments/assets/7c6634ac-8ccc-4d52-94a2-64c71bd96314)
