### PR TITLE
Score not being captured

### DIFF
--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -561,7 +561,7 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
         return 1.0
 
     def allows_rescore(self):
-        return self.has_score and self.scorm_allow_rescore
+        return self.scorm_allow_rescore
 
     def set_score(self, score):
         self.scorm_score = self.max_score() * score.raw_earned / score.raw_possible

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -561,7 +561,7 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
         return 1.0
 
     def allows_rescore(self):
-        return self.scorm_allow_rescore
+        return self.has_score and self.scorm_allow_rescore
 
     def set_score(self, score):
         self.scorm_score = self.max_score() * score.raw_earned / score.raw_possible

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -276,7 +276,7 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
 
     editable_fields = (
         'scorm_pkg', 'scorm_pkg_filename', 'display_name',
-        'has_score', 'weight', 'scorm_allow_rescore',
+        'has_score', 'weight',
         'open_new_tab', 'instruction', 'cover_image'
     )
     has_author_view = True

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -232,7 +232,7 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
     )
 
     scorm_allow_rescore = Boolean(
-        default=False,
+        default=True,
         scope=Scope.settings,
         enforce_type=True,
         display_name=_("Rescore"),


### PR DESCRIPTION
# Task
 - https://foundever.atlassian.net/browse/TRIB-1749

# Relevant / Closed PR
 - https://github.com/Learningtribes/edx_xblock_scorm/pull/58

# Tested In Stage IN
 - [Demo Course](https://studio-stage-in.learning-tribes.com/container/block-v1:edX+BTNSM_V0001+2025-10-10+type@vertical+block@c927d0360c844ced90a61b97d647898d) : 
<img width="1440" height="986" alt="image" src="https://github.com/user-attachments/assets/c744498c-daeb-46fe-9162-b9c4c5c1d0fc" />


# Script for updating the property "scorm_allow_rescore" of SCORM 👇🏻 
 - https://foundever.atlassian.net/browse/TRIB-1749?focusedCommentId=379640
 - I have tested in on Stage IN / CN
```
In [10]: from xmodule.modulestore.django import modulestore
    ...:
    ...:
    ...: store = modulestore()
    ...: courses = store.get_courses()
    ...:
    ...:
    ...: for course in courses:
    ...:     course_key = course.id
    ...:     xblocks = store.get_items(course_key)
    ...:     scorm_xblocks = [b for b in xblocks if b.category == 'scormxblock']
    ...:
    ...:     if scorm_xblocks:
    ...:         for seq, scorm in enumerate(scorm_xblocks, start=1):
    ...:             usage_id = scorm.scope_ids.usage_id
    ...:             if scorm.scorm_allow_rescore:
    ...:                 print('{},{},{}, {},{}'.format(seq, course_key, usage_id, scorm.has_score, scorm.scorm_allow_rescore))
    ...:
1,course-v1:edX+jiayitest+111,block-v1:edX+jiayitest+111+type@scormxblock+block@fce52b2c32574ec8aee9e2dffb0eadf5, False,True
2,course-v1:edX+jiayitest+111,block-v1:edX+jiayitest+111+type@scormxblock+block@1a720d857aae4edd93ddaeaf2d9bb649, False,True
3,course-v1:edX+jiayitest+111,block-v1:edX+jiayitest+111+type@scormxblock+block@a0a05e660af44f05b91becda00e59da5, False,True
1,course-v1:edX+DemoX+Demo_Course,block-v1:edX+DemoX+Demo_Course+type@scormxblock+block@37d200563fa4401a828c46215a90841c, False,True
1,course-v1:edX+nst03+course,block-v1:edX+nst03+course+type@scormxblock+block@0096017145244d3b8d10278d82572515, False,True
1,course-v1:edX+ntcs-00+course,block-v1:edX+ntcs-00+course+type@scormxblock+block@712a0d367843442b8a0099c9d0eb31a0, False,True
1,course-v1:edX+nst01+course,block-v1:edX+nst01+course+type@scormxblock+block@22f005e98cfe44109c37edd7d61c3999, False,True
2,course-v1:edX+nst01+course,block-
......
......
1,course-v1:edX+nst04+course,block-v1:edX+nst04+course+type@scormxblock+block@001b17f7045c482d9e1121a9c7e3e709, False,True
2,course-v1:edX+nst04+course,block-v1:edX+nst04+course+type@scormxblock+block@67e341b1ec7f43e283814a0eac623afb, False,True
1,course-v1:edX+nstn01+course,block-v1:edX+nstn01+course+type@scormxblock+block@aa53467f417e453a870359be259952cb, False,True
1,course-v1:edX+JiayiS3+001,block-v1:edX+JiayiS3+001+type@scormxblock+block@7002ab3174f34328aa155a55c5750e46, False,True

In [11]
```