### PR TITLE
"New Tab" option is now exclusive to Scored SCORM Components

### DIFF
--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -236,7 +236,6 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
         scope=Scope.settings,
         enforce_type=True,
         display_name=_("Rescore"),
-        hidden=True,
         help=_("Does this SCORM allow users to submit answer multiple times?")
     )
 

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -236,6 +236,7 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
         scope=Scope.settings,
         enforce_type=True,
         display_name=_("Rescore"),
+        hidden=True,
         help=_("Does this SCORM allow users to submit answer multiple times?")
     )
 
@@ -276,7 +277,7 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
 
     editable_fields = (
         'scorm_pkg', 'scorm_pkg_filename', 'display_name',
-        'has_score', 'weight',
+        'has_score', 'weight', 'scorm_allow_rescore',
         'open_new_tab', 'instruction', 'cover_image'
     )
     has_author_view = True


### PR DESCRIPTION
# Task
 - https://foundever.atlassian.net/browse/TRIB-1758

# Related PRs
 - https://github.com/Learningtribes/triboo-theme/pull/829

# Tested in Devstack
<img width="1573" height="845" alt="image" src="https://github.com/user-attachments/assets/5624d2be-fd34-4d0d-be09-a4fd34223543" />
<img width="1441" height="724" alt="image" src="https://github.com/user-attachments/assets/56a4c620-d886-4a7f-ad55-8901713a489e" />
<img width="1278" height="751" alt="image" src="https://github.com/user-attachments/assets/f6475f02-2634-46bd-95d4-248c61205ee8" />






