### PR TITLE
Please review this completion issue GDPAT - LAT

### DIFF
--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -150,8 +150,8 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
         default=False,
         scope=Scope.settings,
         enforce_type=True,
-        display_name=_('New Tab'),
-        help=_('Open module in a new tab. This option will only apply to users with a compatible browser.')
+        display_name=_('Fullscreen'),
+        help=_('Open module in fullscreen.')
     )
 
     fs = Filesystem(scope=Scope.settings)

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import division
 
+from copy import deepcopy
 import io
 import os
 import pkg_resources
@@ -753,14 +754,14 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
             return {'error': _('scorm package expired, refresh page to get new content.')}
 
         if package_version == SCORM_VERSION.V12:
-            default = SCORM_12_RUNTIME_DEFAULT
+            default = deepcopy(SCORM_12_RUNTIME_DEFAULT)
             default['cmi.core.student_id'] = str(self.runtime.user_id)
             default['cmi.core.student_name'] = User.objects.get(id=self.runtime.user_id).username
             if self.scorm_runtime_data.get('cmi.core.exit', None):
                 if self.scorm_runtime_data.get('cmi.core.exit') == 'suspend':
                     default['cmi.core.entry'] = 'resume'
         elif package_version == SCORM_VERSION.V2004:
-            default = SCORM_2004_RUNTIME_DEFAULT
+            default = deepcopy(SCORM_2004_RUNTIME_DEFAULT)
             default['cmi.learner_id'] = str(self.runtime.user_id)
             default['cmi.learner_name'] = User.objects.get(id=self.runtime.user_id).username
             if self.scorm_runtime_data.get('cmi.exit', None):

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -134,7 +134,7 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
         values={"min": 0, "step": 0.1},
         enforce_type=True,
         display_name=_('Weight'),
-        help=_('Relative weight in this course section')
+        help=_("Relative weight in this course section")
     )
 
     ratio = String(
@@ -143,15 +143,15 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
         values=("16:9", "4:3", "1:1"),
         enforce_type=True,
         display_name=_('Ratio'),
-        help=_('Aspect ratio of this module')
+        help=_("Aspect ratio of this module")
     )
 
     open_new_tab = Boolean(
         default=False,
         scope=Scope.settings,
         enforce_type=True,
-        display_name=_('Fullscreen'),
-        help=_('Open module in fullscreen.')
+        display_name=_('Full screen'),
+        help=_("Allow the module to open in full screen")
     )
 
     fs = Filesystem(scope=Scope.settings)
@@ -185,15 +185,15 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
         scope=Scope.settings,
         values=SCORM_VERSION,
         enforce_type=True,
-        display_name=_('Version'),
-        help=_('Version of scorm, 1.2 or 2004')
+        display_name=_("Version"),
+        help=_("Version of scorm, 1.2 or 2004")
     )
 
     scorm_pkg_modified = DateTime(
         scope=Scope.settings,
         enforce_type=True,
-        display_name=_('Upload time'),
-        help=_('SCORM package upload time utc')
+        display_name=_("Upload time"),
+        help=_("SCORM package upload time utc")
     )
 
     _scorm_runtime_data = Dict(
@@ -205,8 +205,8 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
     scorm_runtime_modified = DateTime(
         scope=Scope.user_state,
         enforce_type=True,
-        display_name=_('Runtime Modified Time'),
-        help=_('SCORM runtime modified time utc')
+        display_name=_("Runtime Modified Time"),
+        help=_("SCORM runtime modified time utc")
     )
 
     scorm_status = String(
@@ -972,10 +972,12 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
                 self.scorm_status = info['status']
             else:
                 logger.info(
-                    'miss score data of {} within argument [{}] for student {}'.format(
+                    "refused to publish score {} for student id {} in {} [{}]".format(
+                        score.raw_earned,
+                        str(self.runtime.user_id),
                         self.scope_ids.usage_id.to_deprecated_string(),
-                        data,
-                        str(self.runtime.user_id))
+                        data
+                    )
                 )
 
         else:

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -682,9 +682,6 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
                                            'has_score', 'scorm_status', 'scorm_pkg',
                                            'scorm_file', 'lesson_score', 'success_status',
                                            'open_new_tab', 'instruction', 'cover_image')
-        request = get_current_request()
-        if fields_data['open_new_tab_value']:
-            fields_data['open_new_tab_value'] = is_compatible(request)
         fields_data['graded_status'] = 'ungraded'
         if self.graded and fields_data['has_score'] and fields_data['weight'] != 0:
             fields_data['graded_status'] = 'graded'

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -78,17 +78,6 @@ SCORM_STATUS = namedtuple('ScormStatus', [
 SCORM_VERSION = namedtuple('ScormVersion', ['V12', 'V2004'])('SCORM12', 'SCORM2004')
 
 
-def is_compatible(request):
-    """Ignore IE/Safari browsers to open scorm content in new tab due to postMessage() limitation.
-    """
-    http_user_agent = request.META.get('HTTP_USER_AGENT')
-    user_agent = user_agents.parse(http_user_agent)
-    browser_family = user_agent.browser.family
-    if browser_family == 'IE' or "Safari" in browser_family:
-        return False
-    return True
-
-
 @XBlock.needs('request', 'fs', 'i18n', 'user')
 class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
     """
@@ -147,7 +136,7 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
     )
 
     open_new_tab = Boolean(
-        default=False,
+        default=True,
         scope=Scope.settings,
         enforce_type=True,
         display_name=_('Full screen'),
@@ -278,7 +267,7 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
     editable_fields = (
         'scorm_pkg', 'scorm_pkg_filename', 'display_name',
         'has_score', 'weight',
-        'open_new_tab', 'instruction', 'cover_image'
+        'instruction', 'cover_image'
     )
     has_author_view = True
 

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -954,6 +954,16 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
                           raw_possible=(info['maxi'] - info['mini']))
 
         if score:
+            # log the data without suspend_data
+            log_data = deepcopy(data)
+            if log_data.get('cmi.suspend_data'):
+                log_data.pop('cmi.suspend_data')
+            logger.info("scorm_commit SCORE Usage: %s, User: %s, Data: %s",
+                self.scope_ids.usage_id.to_deprecated_string(),
+                self.runtime.user_id,
+                log_data
+            )
+
             if not self.has_submitted_answer() or self.allows_rescore():
                 self.set_score(score)
                 self._publish_grade(self.get_score())
@@ -971,6 +981,17 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
 
         else:
             if info['status'] == SCORM_STATUS.SUCCEED:
+
+                # log the data without suspend_data
+                log_data = deepcopy(data)
+                if log_data.get('cmi.suspend_data'):
+                    log_data.pop('cmi.suspend_data')
+                logger.info("scorm_commit SUCCEED Usage: %s, User: %s, Data: %s",
+                    self.scope_ids.usage_id.to_deprecated_string(),
+                    self.runtime.user_id,
+                    log_data
+                )
+
                 user_id = self.scope_ids.user_id
                 user_obj = User.objects.get(id=user_id)
                 course_key = CourseKey.from_string('{}'.format(self.course_id))

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -970,6 +970,14 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
                 self._publish_grade(self.get_score())
 
                 self.scorm_status = info['status']
+            else:
+                logger.info(
+                    'miss score data of {} within argument [{}] for student {}'.format(
+                        self.scope_ids.usage_id.to_deprecated_string(),
+                        data,
+                        str(self.runtime.user_id))
+                )
+
         else:
             if info['status'] == SCORM_STATUS.SUCCEED:
                 user_id = self.scope_ids.user_id

--- a/scormxblock/static/css/scormxblock.css
+++ b/scormxblock/static/css/scormxblock.css
@@ -21,10 +21,16 @@
 .exit-fullscreen-button {
     cursor: pointer;
     position: fixed;
-    top: 10px;
-    right: 150px;
+    top: 5px;
+    right: 5px;
     z-index: 99999999999;
     background-color: white;
+    height: 30px;
+    wdith: 130px;
+    border-radius: 5px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .scormxblock_hostframe {

--- a/scormxblock/static/css/scormxblock.css
+++ b/scormxblock/static/css/scormxblock.css
@@ -18,6 +18,11 @@
     z-index: 999999;
 }
 
+.exit-fullscreen-button {
+    position: flex;
+    top: 10px;
+}
+
 .scormxblock_hostframe {
 	border: 0;
 	height: 300px;

--- a/scormxblock/static/css/scormxblock.css
+++ b/scormxblock/static/css/scormxblock.css
@@ -15,6 +15,7 @@
     width: 100vw;
     height: 100vh;
     overflow: auto;
+    z-index: 999999;
 }
 
 .scormxblock_hostframe {

--- a/scormxblock/static/css/scormxblock.css
+++ b/scormxblock/static/css/scormxblock.css
@@ -22,8 +22,12 @@
     display: none;
 }
 
-.button-container .fa-expand {
+.fa-expand {
     margin-right: 5px;
+}
+
+.launch-button {
+    margin-top: 10px;
 }
 
 .hidden {

--- a/scormxblock/static/css/scormxblock.css
+++ b/scormxblock/static/css/scormxblock.css
@@ -13,6 +13,9 @@
 
 .scorm_object_container .scorm-object-header {
     display: flex;
+    height: 30px;
+    justify-content: right;
+    align-items: center;
 }
 
  .success_status {
@@ -37,13 +40,9 @@
 
 .exit-fullscreen-button {
     cursor: pointer;
-    position: fixed;
-    top: 5px;
-    right: 16px;
     z-index: 20000;
-    background-color: rgba(255, 255, 255, 0.3);
-    opacity: 0.5;
-    height: 40px;
+    background-color: white;
+    height: 20px;
     width: 125px;
     border-radius: 5px;
     display: flex;

--- a/scormxblock/static/css/scormxblock.css
+++ b/scormxblock/static/css/scormxblock.css
@@ -4,6 +4,11 @@
 	height: 675px;
 	border: none;
  }
+
+.scormxblock_block .scorm_object .scorm-object-header {
+    position: relative;
+}
+
  .success_status {
 	 display: none;
  }

--- a/scormxblock/static/css/scormxblock.css
+++ b/scormxblock/static/css/scormxblock.css
@@ -16,6 +16,7 @@
     height: 100vh !important;
     overflow: auto;
     z-index: 999999;
+    background-color: white;
 }
 
 .exit-fullscreen-button {

--- a/scormxblock/static/css/scormxblock.css
+++ b/scormxblock/static/css/scormxblock.css
@@ -27,7 +27,7 @@
     z-index: 99999999999;
     background-color: white;
     height: 30px;
-    width: 130px;
+    width: 140px;
     border-radius: 5px;
     display: flex;
     align-items: center;

--- a/scormxblock/static/css/scormxblock.css
+++ b/scormxblock/static/css/scormxblock.css
@@ -5,8 +5,14 @@
 	border: none;
  }
 
-.scormxblock_block .scorm_object .scorm-object-header {
-    position: relative;
+.scorm_object_container {
+	width: 100%;
+	height: 675px;
+	border: none;
+}
+
+.scorm_object_container .scorm-object-header {
+    display: flex;
 }
 
  .success_status {

--- a/scormxblock/static/css/scormxblock.css
+++ b/scormxblock/static/css/scormxblock.css
@@ -8,6 +8,14 @@
 	 display: none;
  }
 
+.fullscreen_scormxblock_view {
+    position: fixed;
+    left: 0px;
+    top: 0px;
+    width: 100vw;
+    height: 100vh;
+    overflow: auto;
+}
 
 .scormxblock_hostframe {
 	border: 0;

--- a/scormxblock/static/css/scormxblock.css
+++ b/scormxblock/static/css/scormxblock.css
@@ -28,7 +28,7 @@
     cursor: pointer;
     position: fixed;
     top: 5px;
-    right: 10px;
+    right: 16px;
     z-index: 20000;
     background-color: rgba(255, 255, 255, 0.3);
     opacity: 0.5;

--- a/scormxblock/static/css/scormxblock.css
+++ b/scormxblock/static/css/scormxblock.css
@@ -8,6 +8,11 @@
 	 display: none;
  }
 
+.hidden {
+    display: none !important;
+    visibility: hidden;
+}
+
 .fullscreen_scormxblock_view {
     position: fixed;
     left: 0px;

--- a/scormxblock/static/css/scormxblock.css
+++ b/scormxblock/static/css/scormxblock.css
@@ -12,8 +12,8 @@
     position: fixed;
     left: 0px;
     top: 0px;
-    width: 100vw;
-    height: 100vh;
+    width: 100vw !important;
+    height: 100vh !important;
     overflow: auto;
     z-index: 999999;
 }

--- a/scormxblock/static/css/scormxblock.css
+++ b/scormxblock/static/css/scormxblock.css
@@ -26,11 +26,15 @@
     z-index: 99999999999;
     background-color: white;
     height: 30px;
-    wdith: 130px;
+    width: 130px;
     border-radius: 5px;
     display: flex;
     align-items: center;
     justify-content: center;
+}
+
+.fa-xmark-large {
+    margin-right: 5px;
 }
 
 .scormxblock_hostframe {

--- a/scormxblock/static/css/scormxblock.css
+++ b/scormxblock/static/css/scormxblock.css
@@ -20,7 +20,7 @@
     width: 100vw !important;
     height: 100vh !important;
     overflow: auto;
-    z-index: 999999;
+    z-index: 10002;
     background-color: white;
 }
 
@@ -29,7 +29,7 @@
     position: fixed;
     top: 5px;
     right: 5px;
-    z-index: 99999999999;
+    z-index: 20000;
     background-color: white;
     height: 30px;
     width: 140px;

--- a/scormxblock/static/css/scormxblock.css
+++ b/scormxblock/static/css/scormxblock.css
@@ -18,9 +18,13 @@
     align-items: center;
 }
 
- .success_status {
-	 display: none;
- }
+.success_status {
+    display: none;
+}
+
+.button-container .fa-expand {
+    margin-right: 5px;
+}
 
 .hidden {
     display: none !important;
@@ -55,7 +59,7 @@
     opacity: 1;
 }
 
-.fa-xmark-large {
+.fa-compress {
     margin-right: 5px;
 }
 

--- a/scormxblock/static/css/scormxblock.css
+++ b/scormxblock/static/css/scormxblock.css
@@ -3,19 +3,15 @@
 	width: 100%;
 	height: 675px;
 	border: none;
- }
+}
 
 .scorm_object_container {
 	width: 100%;
-	height: 675px;
 	border: none;
 }
 
 .scorm_object_container .scorm-object-header {
-    display: flex;
-    height: 30px;
-    justify-content: right;
-    align-items: center;
+    display: none;
 }
 
 .success_status {
@@ -44,6 +40,13 @@
     overflow: auto;
     z-index: 10002;
     background-color: white;
+}
+
+.fullscreen_scormxblock_view .scorm-object-header {
+    display: flex;
+    height: 30px;
+    justify-content: right;
+    align-items: center;
 }
 
 .exit-fullscreen-button {

--- a/scormxblock/static/css/scormxblock.css
+++ b/scormxblock/static/css/scormxblock.css
@@ -34,6 +34,10 @@
     justify-content: center;
 }
 
+.close-button-text {
+    background-color: white;
+}
+
 .fa-xmark-large {
     margin-right: 5px;
 }

--- a/scormxblock/static/css/scormxblock.css
+++ b/scormxblock/static/css/scormxblock.css
@@ -47,7 +47,7 @@
     z-index: 20000;
     background-color: white;
     height: 20px;
-    width: 125px;
+    width: 230px;
     border-radius: 5px;
     display: flex;
     align-items: center;

--- a/scormxblock/static/css/scormxblock.css
+++ b/scormxblock/static/css/scormxblock.css
@@ -19,8 +19,10 @@
 }
 
 .exit-fullscreen-button {
-    position: flex;
-    top: 10px;
+    cursor: pointer;
+    position: fixed;
+    top: 20px;
+    right: 60px;
 }
 
 .scormxblock_hostframe {

--- a/scormxblock/static/css/scormxblock.css
+++ b/scormxblock/static/css/scormxblock.css
@@ -5,6 +5,12 @@
 	border: none;
 }
 
+.scormxblock_block .fullscreen_scormxblock_view .scorm_object {
+	width: 100%;
+	height: calc(100vh - 30px) !important;
+	border: none;
+}
+
 .scorm_object_container {
 	width: 100%;
 	border: none;

--- a/scormxblock/static/css/scormxblock.css
+++ b/scormxblock/static/css/scormxblock.css
@@ -28,19 +28,21 @@
     cursor: pointer;
     position: fixed;
     top: 5px;
-    right: 5px;
+    right: 10px;
     z-index: 20000;
-    background-color: white;
-    height: 30px;
-    width: 140px;
+    background-color: rgba(255, 255, 255, 0.3);
+    opacity: 0.5;
+    height: 40px;
+    width: 125px;
     border-radius: 5px;
     display: flex;
     align-items: center;
     justify-content: center;
 }
 
-.close-button-text {
+.exit-fullscreen-button:hover {
     background-color: white;
+    opacity: 1;
 }
 
 .fa-xmark-large {

--- a/scormxblock/static/css/scormxblock.css
+++ b/scormxblock/static/css/scormxblock.css
@@ -21,8 +21,10 @@
 .exit-fullscreen-button {
     cursor: pointer;
     position: fixed;
-    top: 20px;
-    right: 60px;
+    top: 10px;
+    right: 150px;
+    z-index: 99999999999;
+    background-color: white;
 }
 
 .scormxblock_hostframe {

--- a/scormxblock/static/html/author_view.html
+++ b/scormxblock/static/html/author_view.html
@@ -1,6 +1,10 @@
 {% load i18n %}
 {% if scorm_pkg_value %}
 <div class="themeable-xblock scormxblock_block">
+    <div class="exit-fullscreen-button hidden">
+        <i class="fa-regular fa-xmark-large"></i>
+        <span class="close-button-text">{% trans 'Close' %}</span>
+    </div>
     {% if open_new_tab_value %}
     <div class="launch-div">
         <div class="instruction">{{ instruction_value }}</div>
@@ -12,6 +16,7 @@
             </div>
         </div>
     </div>
+    <iframe id="scorm-object-frame" class="scorm_object hidden" data-src="{{ scorm_pkg_value }}"></iframe>
     {% else %}
     <iframe id="scorm-object-frame" class="scorm_object" src="{{ cms_path }}"></iframe>
     {% endif %}

--- a/scormxblock/static/html/author_view.html
+++ b/scormxblock/static/html/author_view.html
@@ -12,17 +12,19 @@
         <div class="scorm_object_container">
             <div class="scorm-object-header hidden">
                 <div class="exit-fullscreen-button">
-                    <i class="fa-regular fa-xmark-large"></i>
-                    <span class="close-button-text">{% trans 'Close' %}</span>
+                    <i class="fa-solid fa-compress"></i>
+                    <span class="close-button-text">{% trans 'Exit full screen' %}</span>
                 </div>
             </div>
             <iframe id="scorm-object-frame" class="scorm_object" src="{{ cms_path }}"></iframe>
         </div>
 
         <div class="description">
-            <h2 class="content-title">{% trans "Open in full screen" %}</h2>
             <div class="button-container">
-                <button class="launch-button">{% trans "Launch" %}</button>
+                <button class="launch-button">
+                    <i class="fa-solid fa-expand"></i>
+                    {% trans "Full screen" %}
+                </button>
             </div>
         </div>
     </div>

--- a/scormxblock/static/html/author_view.html
+++ b/scormxblock/static/html/author_view.html
@@ -16,7 +16,7 @@
             </div>
         </div>
     </div>
-    <iframe id="scorm-object-frame" class="scorm_object hidden" data-src="{{ cms_path }}"></iframe>
+    <iframe id="scorm-object-frame" class="scorm_object hidden" src="{{ cms_path }}"></iframe>
     {% else %}
     <iframe id="scorm-object-frame" class="scorm_object" src="{{ cms_path }}"></iframe>
     {% endif %}

--- a/scormxblock/static/html/author_view.html
+++ b/scormxblock/static/html/author_view.html
@@ -20,12 +20,10 @@
         </div>
 
         <div class="description">
-            <div class="button-container">
-                <button class="launch-button">
-                    <i class="fa-solid fa-expand"></i>
-                    {% trans "Full screen" %}
-                </button>
-            </div>
+            <button class="ds-button launch-button">
+                <i class="fa-solid fa-expand"></i>
+                {% trans "Full screen" %}
+            </button>
         </div>
     </div>
     {% else %}

--- a/scormxblock/static/html/author_view.html
+++ b/scormxblock/static/html/author_view.html
@@ -10,7 +10,7 @@
         <div class="instruction">{{ instruction_value }}</div>
         <div class="preview">{% if cover_image_value %}<img src="{{ cover_image_value }}" alt="preview" />{% endif %}</div>
         <div class="description">
-            <h2 class="content-title">{% trans "Open in fullscreen" %}</h2>
+            <h2 class="content-title">{% trans "Open in full screen" %}</h2>
             <div class="button-container">
                 <button class="launch-button">{% trans "Launch" %}</button>
             </div>

--- a/scormxblock/static/html/author_view.html
+++ b/scormxblock/static/html/author_view.html
@@ -9,7 +9,6 @@
             <h2 class="content-title">{% trans "Open in fullscreen" %}</h2>
             <div class="button-container">
                 <button class="launch-button"><a href="{{ lms_root_url }}{{ scorm_pkg_value }}" rel="opener" target="_blank">{% trans "Launch" %}</a></button>
-                <a role="button" class="fresh-button btn" href="javascript:window.location.reload();"><i class="fal fa-redo-alt"></i>{% trans "Refresh" %}</a>
             </div>
         </div>
     </div>

--- a/scormxblock/static/html/author_view.html
+++ b/scormxblock/static/html/author_view.html
@@ -8,7 +8,7 @@
         <div class="description">
             <h2 class="content-title">{% trans "Open in fullscreen" %}</h2>
             <div class="button-container">
-                <button class="launch-button"><a href="{{ lms_root_url }}{{ scorm_pkg_value }}" rel="opener" target="_blank">{% trans "Launch" %}</a></button>
+                <button class="launch-button">{% trans "Launch" %}</button>
             </div>
         </div>
     </div>

--- a/scormxblock/static/html/author_view.html
+++ b/scormxblock/static/html/author_view.html
@@ -8,7 +8,9 @@
     {% if open_new_tab_value %}
     <div class="launch-div">
         <div class="instruction">{{ instruction_value }}</div>
-        <div class="preview">{% if cover_image_value %}<img src="{{ cover_image_value }}" alt="preview" />{% endif %}</div>
+
+        <iframe id="scorm-object-frame" class="scorm_object" src="{{ cms_path }}"></iframe>
+
         <div class="description">
             <h2 class="content-title">{% trans "Open in full screen" %}</h2>
             <div class="button-container">
@@ -16,7 +18,6 @@
             </div>
         </div>
     </div>
-    <iframe id="scorm-object-frame" class="scorm_object hidden" src="{{ cms_path }}"></iframe>
     {% else %}
     <iframe id="scorm-object-frame" class="scorm_object" src="{{ cms_path }}"></iframe>
     {% endif %}

--- a/scormxblock/static/html/author_view.html
+++ b/scormxblock/static/html/author_view.html
@@ -16,7 +16,7 @@
             </div>
         </div>
     </div>
-    <iframe id="scorm-object-frame" class="scorm_object hidden" data-src="{{ scorm_pkg_value }}"></iframe>
+    <iframe id="scorm-object-frame" class="scorm_object hidden" data-src="{{ cms_path }}"></iframe>
     {% else %}
     <iframe id="scorm-object-frame" class="scorm_object" src="{{ cms_path }}"></iframe>
     {% endif %}

--- a/scormxblock/static/html/author_view.html
+++ b/scormxblock/static/html/author_view.html
@@ -10,7 +10,7 @@
         <div class="instruction">{{ instruction_value }}</div>
 
         <div class="scorm_object_container">
-            <div class="scorm-object-header hidden">
+            <div class="scorm-object-header">
                 <div class="exit-fullscreen-button">
                     <i class="fa-solid fa-compress"></i>
                     <span class="close-button-text">{% trans 'Exit full screen' %}</span>

--- a/scormxblock/static/html/author_view.html
+++ b/scormxblock/static/html/author_view.html
@@ -9,7 +9,15 @@
     <div class="launch-div">
         <div class="instruction">{{ instruction_value }}</div>
 
-        <iframe id="scorm-object-frame" class="scorm_object" src="{{ cms_path }}"></iframe>
+        <div class="scorm_object_container">
+            <div class="scorm-object-header hidden">
+                <div class="exit-fullscreen-button">
+                    <i class="fa-regular fa-xmark-large"></i>
+                    <span class="close-button-text">{% trans 'Close' %}</span>
+                </div>
+            </div>
+            <iframe id="scorm-object-frame" class="scorm_object" src="{{ cms_path }}"></iframe>
+        </div>
 
         <div class="description">
             <h2 class="content-title">{% trans "Open in full screen" %}</h2>

--- a/scormxblock/static/html/author_view.html
+++ b/scormxblock/static/html/author_view.html
@@ -6,9 +6,7 @@
         <div class="instruction">{{ instruction_value }}</div>
         <div class="preview">{% if cover_image_value %}<img src="{{ cover_image_value }}" alt="preview" />{% endif %}</div>
         <div class="description">
-            <h2 class="content-title">{% trans "Open in a new tab" %}</h2>
-            <p class="launch-content launch-before">{% trans "Click on the button below to open the module in a new tab. If the module does not open properly, please refresh the page" %}</p>
-            <p class="launch-content launch-after hidden">{% trans "Your e-learning module has been opened in a new tab. Please, close the new tab after you completed the module." %}</p>
+            <h2 class="content-title">{% trans "Open in fullscreen" %}</h2>
             <div class="button-container">
                 <button class="launch-button"><a href="{{ lms_root_url }}{{ scorm_pkg_value }}" rel="opener" target="_blank">{% trans "Launch" %}</a></button>
                 <a role="button" class="fresh-button btn" href="javascript:window.location.reload();"><i class="fal fa-redo-alt"></i>{% trans "Refresh" %}</a>

--- a/scormxblock/static/html/scormxblock.html
+++ b/scormxblock/static/html/scormxblock.html
@@ -29,7 +29,7 @@
             </div>
         </div>
     </div>
-    <iframe id="scorm-object-frame" class="scorm_object hidden" data-src="{{ scorm_pkg_value }}"></iframe>
+    <iframe id="scorm-object-frame" class="scorm_object" data-src="{{ scorm_pkg_value }}" style="height: 0px"></iframe>
     {% elif scorm_pkg_value %}
         <iframe id="scorm-object-frame" class="scorm_object" data-src="{{ scorm_pkg_value }}"></iframe>
     {% endif %}

--- a/scormxblock/static/html/scormxblock.html
+++ b/scormxblock/static/html/scormxblock.html
@@ -10,10 +10,6 @@
             <span class="success_status">{{ scorm_status_value }}</span>
         </p>
         {% endif %}
-        <div class="exit-fullscreen-button hidden">
-            <i class="fa-regular fa-xmark-large"></i>
-            <span class="close-button-text">{% trans 'Close' %}</span>
-        </div>
     </div>
       <div class="block-label scorm-label">
         <span class="fal fa-file-audio block-label-icon"></span>
@@ -24,7 +20,14 @@
     <div class="launch-div">
         <div class="instruction">{{ instruction_value }}</div>
 
-        <iframe id="scorm-object-frame" class="scorm_object" data-src="{{ scorm_pkg_value }}"></iframe>
+        <iframe id="scorm-object-frame" class="scorm_object" data-src="{{ scorm_pkg_value }}">
+            <div class="scorm-object-header">
+                <div class="exit-fullscreen-button hidden">
+                    <i class="fa-regular fa-xmark-large"></i>
+                    <span class="close-button-text">{% trans 'Close' %}</span>
+                </div>
+            </div>
+        </iframe>
 
         <div class="description">
             <h2 class="content-title">{% trans "Open in full screen" %}</h2>

--- a/scormxblock/static/html/scormxblock.html
+++ b/scormxblock/static/html/scormxblock.html
@@ -25,7 +25,7 @@
             <p class="launch-content launch-before">{% trans "Click on the button below to open the module in a new tab. If the module does not open properly, please refresh the page" %}</p>
             <p class="launch-content launch-after hidden">{% trans "Your e-learning module has been opened in a new tab. Please, close the new tab after you completed the module." %}</p>
             <div class="button-container">
-                <button class="launch-button"><a href="{{ scorm_pkg_value }}" rel="opener" target="_blank">{% trans "Launch" %}</a></button>
+                <button class="launch-button">{% trans "Launch" %}</button>
             </div>
         </div>
     </div>

--- a/scormxblock/static/html/scormxblock.html
+++ b/scormxblock/static/html/scormxblock.html
@@ -20,14 +20,15 @@
     <div class="launch-div">
         <div class="instruction">{{ instruction_value }}</div>
 
-        <iframe id="scorm-object-frame" class="scorm_object" data-src="{{ scorm_pkg_value }}">
+        <div class="scorm_object_container">
             <div class="scorm-object-header">
                 <div class="exit-fullscreen-button hidden">
                     <i class="fa-regular fa-xmark-large"></i>
                     <span class="close-button-text">{% trans 'Close' %}</span>
                 </div>
             </div>
-        </iframe>
+            <iframe id="scorm-object-frame" class="scorm_object" data-src="{{ scorm_pkg_value }}"></iframe>
+        </div>
 
         <div class="description">
             <h2 class="content-title">{% trans "Open in full screen" %}</h2>

--- a/scormxblock/static/html/scormxblock.html
+++ b/scormxblock/static/html/scormxblock.html
@@ -21,8 +21,8 @@
         <div class="instruction">{{ instruction_value }}</div>
 
         <div class="scorm_object_container">
-            <div class="scorm-object-header">
-                <div class="exit-fullscreen-button hidden">
+            <div class="scorm-object-header hidden">
+                <div class="exit-fullscreen-button">
                     <i class="fa-regular fa-xmark-large"></i>
                     <span class="close-button-text">{% trans 'Close' %}</span>
                 </div>

--- a/scormxblock/static/html/scormxblock.html
+++ b/scormxblock/static/html/scormxblock.html
@@ -10,8 +10,8 @@
             <span class="success_status">{{ scorm_status_value }}</span>
         </p>
         {% endif %}
-        <div class="exit-fullscreen-button">
-            <i class="fa-thin fa-xmark"></i>
+        <div class="exit-fullscreen-button hidden">
+            <i class="fa-regular fa-xmark-large"></i>
         </div>
     </div>
       <div class="block-label scorm-label">

--- a/scormxblock/static/html/scormxblock.html
+++ b/scormxblock/static/html/scormxblock.html
@@ -21,7 +21,7 @@
         <div class="instruction">{{ instruction_value }}</div>
 
         <div class="scorm_object_container">
-            <div class="scorm-object-header hidden">
+            <div class="scorm-object-header">
                 <div class="exit-fullscreen-button">
                     <i class="fa-solid fa-compress"></i>
                     <span class="close-button-text">{% trans 'Exit full screen' %}</span>

--- a/scormxblock/static/html/scormxblock.html
+++ b/scormxblock/static/html/scormxblock.html
@@ -25,7 +25,7 @@
         <div class="instruction">{{ instruction_value }}</div>
         <div class="preview">{% if cover_image_value %}<img src="{{ cover_image_value }}" alt="preview" />{% endif %}</div>
         <div class="description">
-            <h2 class="content-title">{% trans "Open in fullscreen" %}</h2>
+            <h2 class="content-title">{% trans "Open in full screen" %}</h2>
             <div class="button-container">
                 <button class="launch-button">{% trans "Launch" %}</button>
             </div>

--- a/scormxblock/static/html/scormxblock.html
+++ b/scormxblock/static/html/scormxblock.html
@@ -23,7 +23,9 @@
     {% if open_new_tab_value and scorm_pkg_value %}
     <div class="launch-div">
         <div class="instruction">{{ instruction_value }}</div>
-        <div class="preview">{% if cover_image_value %}<img src="{{ cover_image_value }}" alt="preview" />{% endif %}</div>
+
+        <iframe id="scorm-object-frame" class="scorm_object hidden" data-src="{{ scorm_pkg_value }}"></iframe>
+
         <div class="description">
             <h2 class="content-title">{% trans "Open in full screen" %}</h2>
             <div class="button-container">
@@ -31,7 +33,6 @@
             </div>
         </div>
     </div>
-    <iframe id="scorm-object-frame" class="scorm_object hidden" data-src="{{ scorm_pkg_value }}"></iframe>
     {% elif scorm_pkg_value %}
         <iframe id="scorm-object-frame" class="scorm_object" data-src="{{ scorm_pkg_value }}"></iframe>
     {% endif %}

--- a/scormxblock/static/html/scormxblock.html
+++ b/scormxblock/static/html/scormxblock.html
@@ -1,33 +1,31 @@
 {% load i18n %}
 <div class="themeable-xblock scormxblock_block">
-    <div id="id-scormxblock-launcher">
-        <div class="block-header-wrapper scorm-header-wrapper">
-            <h3 class="scorm-header">{{ display_name }}</h3>
-            {% if has_score_value %}
-            <p class="scorm_process">
-                <span class="fal fa-bullseye-pointer"></span>
-                <span class="lesson_score">{{ scorm_score_value }}</span>
-                <span class="static_score">/{% blocktrans count weight_value as num_points %}{{ num_points }} point possible{% plural %}{{num_points }} points possible{% endblocktrans %} ({% trans graded_status %})</span>
-                <span class="success_status">{{ scorm_status_value }}</span>
-            </p>
-            {% endif %}
-        </div>
-          <div class="block-label scorm-label">
-            <span class="fal fa-file-audio block-label-icon"></span>
-            <span class="block-label-text">{% trans 'SCORM' %}</span>
-          </div>
-        <hr class="sep-line">
-        {% if open_new_tab_value and scorm_pkg_value %}
-        <div class="launch-div">
-            <div class="instruction">{{ instruction_value }}</div>
-            <div class="preview">{% if cover_image_value %}<img src="{{ cover_image_value }}" alt="preview" />{% endif %}</div>
-            <div class="description">
-                <h2 class="content-title">{% trans "Open in a new tab" %}</h2>
-                <p class="launch-content launch-before">{% trans "Click on the button below to open the module in a new tab. If the module does not open properly, please refresh the page" %}</p>
-                <p class="launch-content launch-after hidden">{% trans "Your e-learning module has been opened in a new tab. Please, close the new tab after you completed the module." %}</p>
-                <div class="button-container">
-                    <button class="launch-button">{% trans "Launch" %}</button>
-                </div>
+    <div class="block-header-wrapper scorm-header-wrapper">
+        <h3 class="scorm-header">{{ display_name }}</h3>
+        {% if has_score_value %}
+        <p class="scorm_process">
+            <span class="fal fa-bullseye-pointer"></span>
+            <span class="lesson_score">{{ scorm_score_value }}</span>
+            <span class="static_score">/{% blocktrans count weight_value as num_points %}{{ num_points }} point possible{% plural %}{{num_points }} points possible{% endblocktrans %} ({% trans graded_status %})</span>
+            <span class="success_status">{{ scorm_status_value }}</span>
+        </p>
+        {% endif %}
+    </div>
+      <div class="block-label scorm-label">
+        <span class="fal fa-file-audio block-label-icon"></span>
+        <span class="block-label-text">{% trans 'SCORM' %}</span>
+      </div>
+    <hr class="sep-line">
+    {% if open_new_tab_value and scorm_pkg_value %}
+    <div class="launch-div">
+        <div class="instruction">{{ instruction_value }}</div>
+        <div class="preview">{% if cover_image_value %}<img src="{{ cover_image_value }}" alt="preview" />{% endif %}</div>
+        <div class="description">
+            <h2 class="content-title">{% trans "Open in a new tab" %}</h2>
+            <p class="launch-content launch-before">{% trans "Click on the button below to open the module in a new tab. If the module does not open properly, please refresh the page" %}</p>
+            <p class="launch-content launch-after hidden">{% trans "Your e-learning module has been opened in a new tab. Please, close the new tab after you completed the module." %}</p>
+            <div class="button-container">
+                <button class="launch-button">{% trans "Launch" %}</button>
             </div>
         </div>
     </div>

--- a/scormxblock/static/html/scormxblock.html
+++ b/scormxblock/static/html/scormxblock.html
@@ -23,17 +23,19 @@
         <div class="scorm_object_container">
             <div class="scorm-object-header hidden">
                 <div class="exit-fullscreen-button">
-                    <i class="fa-regular fa-xmark-large"></i>
-                    <span class="close-button-text">{% trans 'Close' %}</span>
+                    <i class="fa-solid fa-compress"></i>
+                    <span class="close-button-text">{% trans 'Exit full screen' %}</span>
                 </div>
             </div>
             <iframe id="scorm-object-frame" class="scorm_object" data-src="{{ scorm_pkg_value }}"></iframe>
         </div>
 
         <div class="description">
-            <h2 class="content-title">{% trans "Open in full screen" %}</h2>
             <div class="button-container">
-                <button class="launch-button">{% trans "Launch" %}</button>
+                <button class="launch-button">
+                    <i class="fa-solid fa-expand"></i>
+                    {% trans "Full screen" %}
+                </button>
             </div>
         </div>
     </div>

--- a/scormxblock/static/html/scormxblock.html
+++ b/scormxblock/static/html/scormxblock.html
@@ -12,7 +12,7 @@
         {% endif %}
         <div class="exit-fullscreen-button hidden">
             <i class="fa-regular fa-xmark-large"></i>
-            {% trans 'Exit' %}
+            {% trans 'Close' %}
         </div>
     </div>
       <div class="block-label scorm-label">

--- a/scormxblock/static/html/scormxblock.html
+++ b/scormxblock/static/html/scormxblock.html
@@ -1,31 +1,33 @@
 {% load i18n %}
 <div class="themeable-xblock scormxblock_block">
-    <div class="block-header-wrapper scorm-header-wrapper">
-        <h3 class="scorm-header">{{ display_name }}</h3>
-        {% if has_score_value %}
-        <p class="scorm_process">
-            <span class="fal fa-bullseye-pointer"></span>
-            <span class="lesson_score">{{ scorm_score_value }}</span>
-            <span class="static_score">/{% blocktrans count weight_value as num_points %}{{ num_points }} point possible{% plural %}{{num_points }} points possible{% endblocktrans %} ({% trans graded_status %})</span>
-            <span class="success_status">{{ scorm_status_value }}</span>
-        </p>
-        {% endif %}
-    </div>
-      <div class="block-label scorm-label">
-        <span class="fal fa-file-audio block-label-icon"></span>
-        <span class="block-label-text">{% trans 'SCORM' %}</span>
-      </div>
-    <hr class="sep-line">
-    {% if open_new_tab_value and scorm_pkg_value %}
-    <div class="launch-div">
-        <div class="instruction">{{ instruction_value }}</div>
-        <div class="preview">{% if cover_image_value %}<img src="{{ cover_image_value }}" alt="preview" />{% endif %}</div>
-        <div class="description">
-            <h2 class="content-title">{% trans "Open in a new tab" %}</h2>
-            <p class="launch-content launch-before">{% trans "Click on the button below to open the module in a new tab. If the module does not open properly, please refresh the page" %}</p>
-            <p class="launch-content launch-after hidden">{% trans "Your e-learning module has been opened in a new tab. Please, close the new tab after you completed the module." %}</p>
-            <div class="button-container">
-                <button class="launch-button">{% trans "Launch" %}</button>
+    <div id="id-scormxblock-launcher">
+        <div class="block-header-wrapper scorm-header-wrapper">
+            <h3 class="scorm-header">{{ display_name }}</h3>
+            {% if has_score_value %}
+            <p class="scorm_process">
+                <span class="fal fa-bullseye-pointer"></span>
+                <span class="lesson_score">{{ scorm_score_value }}</span>
+                <span class="static_score">/{% blocktrans count weight_value as num_points %}{{ num_points }} point possible{% plural %}{{num_points }} points possible{% endblocktrans %} ({% trans graded_status %})</span>
+                <span class="success_status">{{ scorm_status_value }}</span>
+            </p>
+            {% endif %}
+        </div>
+          <div class="block-label scorm-label">
+            <span class="fal fa-file-audio block-label-icon"></span>
+            <span class="block-label-text">{% trans 'SCORM' %}</span>
+          </div>
+        <hr class="sep-line">
+        {% if open_new_tab_value and scorm_pkg_value %}
+        <div class="launch-div">
+            <div class="instruction">{{ instruction_value }}</div>
+            <div class="preview">{% if cover_image_value %}<img src="{{ cover_image_value }}" alt="preview" />{% endif %}</div>
+            <div class="description">
+                <h2 class="content-title">{% trans "Open in a new tab" %}</h2>
+                <p class="launch-content launch-before">{% trans "Click on the button below to open the module in a new tab. If the module does not open properly, please refresh the page" %}</p>
+                <p class="launch-content launch-after hidden">{% trans "Your e-learning module has been opened in a new tab. Please, close the new tab after you completed the module." %}</p>
+                <div class="button-container">
+                    <button class="launch-button">{% trans "Launch" %}</button>
+                </div>
             </div>
         </div>
     </div>

--- a/scormxblock/static/html/scormxblock.html
+++ b/scormxblock/static/html/scormxblock.html
@@ -26,10 +26,10 @@
             <p class="launch-content launch-after hidden">{% trans "Your e-learning module has been opened in a new tab. Please, close the new tab after you completed the module." %}</p>
             <div class="button-container">
                 <button class="launch-button"><a href="{{ scorm_pkg_value }}" rel="opener" target="_blank">{% trans "Launch" %}</a></button>
-                <a role="button" class="fresh-button btn" href="javascript:window.location.reload();"><i class="fal fa-redo-alt"></i>{% trans "Refresh" %}</a>
             </div>
         </div>
     </div>
+    <iframe id="scorm-object-frame" class="scorm_object hidden" data-src="{{ scorm_pkg_value }}"></iframe>
     {% elif scorm_pkg_value %}
         <iframe id="scorm-object-frame" class="scorm_object" data-src="{{ scorm_pkg_value }}"></iframe>
     {% endif %}

--- a/scormxblock/static/html/scormxblock.html
+++ b/scormxblock/static/html/scormxblock.html
@@ -10,6 +10,9 @@
             <span class="success_status">{{ scorm_status_value }}</span>
         </p>
         {% endif %}
+        <div class="exit-fullscreen-button">
+            <i class="fa-thin fa-xmark"></i>
+        </div>
     </div>
       <div class="block-label scorm-label">
         <span class="fal fa-file-audio block-label-icon"></span>

--- a/scormxblock/static/html/scormxblock.html
+++ b/scormxblock/static/html/scormxblock.html
@@ -29,7 +29,7 @@
             </div>
         </div>
     </div>
-    <iframe id="scorm-object-frame" class="scorm_object" data-src="{{ scorm_pkg_value }}" style="height: 0px"></iframe>
+    <iframe id="scorm-object-frame" class="scorm_object hidden" data-src="{{ scorm_pkg_value }}"></iframe>
     {% elif scorm_pkg_value %}
         <iframe id="scorm-object-frame" class="scorm_object" data-src="{{ scorm_pkg_value }}"></iframe>
     {% endif %}

--- a/scormxblock/static/html/scormxblock.html
+++ b/scormxblock/static/html/scormxblock.html
@@ -12,7 +12,7 @@
         {% endif %}
         <div class="exit-fullscreen-button hidden">
             <i class="fa-regular fa-xmark-large"></i>
-            {% trans 'Close' %}
+            <span class="close-button-text">{% trans 'Close' %}</span>
         </div>
     </div>
       <div class="block-label scorm-label">

--- a/scormxblock/static/html/scormxblock.html
+++ b/scormxblock/static/html/scormxblock.html
@@ -12,6 +12,7 @@
         {% endif %}
         <div class="exit-fullscreen-button hidden">
             <i class="fa-regular fa-xmark-large"></i>
+            {% trans 'Exit' %}
         </div>
     </div>
       <div class="block-label scorm-label">

--- a/scormxblock/static/html/scormxblock.html
+++ b/scormxblock/static/html/scormxblock.html
@@ -24,7 +24,7 @@
     <div class="launch-div">
         <div class="instruction">{{ instruction_value }}</div>
 
-        <iframe id="scorm-object-frame" class="scorm_object hidden" data-src="{{ scorm_pkg_value }}"></iframe>
+        <iframe id="scorm-object-frame" class="scorm_object" data-src="{{ scorm_pkg_value }}"></iframe>
 
         <div class="description">
             <h2 class="content-title">{% trans "Open in full screen" %}</h2>

--- a/scormxblock/static/html/scormxblock.html
+++ b/scormxblock/static/html/scormxblock.html
@@ -31,12 +31,10 @@
         </div>
 
         <div class="description">
-            <div class="button-container">
-                <button class="launch-button">
-                    <i class="fa-solid fa-expand"></i>
-                    {% trans "Full screen" %}
-                </button>
-            </div>
+            <button class="ds-button launch-button">
+                <i class="fa-solid fa-expand"></i>
+                {% trans "Full screen" %}
+            </button>
         </div>
     </div>
     {% elif scorm_pkg_value %}

--- a/scormxblock/static/html/scormxblock.html
+++ b/scormxblock/static/html/scormxblock.html
@@ -25,9 +25,7 @@
         <div class="instruction">{{ instruction_value }}</div>
         <div class="preview">{% if cover_image_value %}<img src="{{ cover_image_value }}" alt="preview" />{% endif %}</div>
         <div class="description">
-            <h2 class="content-title">{% trans "Open in a new tab" %}</h2>
-            <p class="launch-content launch-before">{% trans "Click on the button below to open the module in a new tab. If the module does not open properly, please refresh the page" %}</p>
-            <p class="launch-content launch-after hidden">{% trans "Your e-learning module has been opened in a new tab. Please, close the new tab after you completed the module." %}</p>
+            <h2 class="content-title">{% trans "Open in fullscreen" %}</h2>
             <div class="button-container">
                 <button class="launch-button">{% trans "Launch" %}</button>
             </div>

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -34,21 +34,15 @@
 
             $('.exit-fullscreen-button').click(function() {
                 let iframe = $('.xblock-student_view[data-usage-id="'+usageId+'"] #scorm-object-frame');
-                $('.xblock-student_view[data-usage-id="'+usageId+'"] .launch-div').removeClass('hidden');
                 $('.xblock-student_view[data-usage-id="'+usageId+'"] .exit-fullscreen-button').addClass('hidden');
                 iframe.removeClass('fullscreen_scormxblock_view');
 
                 iframe.addClass('hidden');
                 iframe.css('height', '0px');
-
-                $('.launch-button').removeClass('disabled');
-                $('.launch-before').toggleClass('hidden');
-                $('.launch-after').toggleClass('hidden');
             })
 
             $('.launch-button').click(function() {
                 let iframe = $('.xblock-student_view[data-usage-id="'+usageId+'"] #scorm-object-frame');
-                $('.xblock-student_view[data-usage-id="'+usageId+'"] .launch-div').addClass('hidden');
                 iframe.addClass('fullscreen_scormxblock_view');
                 $('.xblock-student_view[data-usage-id="'+usageId+'"] .exit-fullscreen-button').removeClass('hidden');
 
@@ -58,9 +52,6 @@
                     iframe.css('height', '100vh');
                 });
 
-                $('.launch-button').addClass('disabled');
-                $('.launch-before').toggleClass('hidden');
-                $('.launch-after').toggleClass('hidden');
             })
 
             // Get runtime score value due to unexpected terminal action

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -121,6 +121,9 @@
         function Terminate(value) {
             Commit(value);
             clearInterval(timerId);
+
+            quitFullscreen();
+
             return 'true';
         }
 

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -35,10 +35,15 @@
             $('.exit-fullscreen-button').click(function() {
                 let iframe = $('.xblock-student_view[data-usage-id="'+usageId+'"] #scorm-object-frame');
                 $('.xblock-student_view[data-usage-id="'+usageId+'"] .launch-div').removeClass('hidden');
+                $('.xblock-student_view[data-usage-id="'+usageId+'"] .exit-fullscreen-button').removeClass('hidden');
                 $('.xblock-student_view[data-usage-id="'+usageId+'"]').removeClass('fullscreen_scormxblock_view');
 
                 iframe.addClass('hidden');
                 iframe.css('height', '0px');
+
+                $('.launch-button').removeClass('disabled');
+                $('.launch-before').toggleClass('hidden');
+                $('.launch-after').toggleClass('hidden');
             })
 
             $('.launch-button').click(function() {

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -36,7 +36,7 @@
                 let iframe = $('.xblock-student_view[data-usage-id="'+usageId+'"] #scorm-object-frame');
                 $('.xblock-student_view[data-usage-id="'+usageId+'"] .launch-div').removeClass('hidden');
                 $('.xblock-student_view[data-usage-id="'+usageId+'"] .exit-fullscreen-button').addClass('hidden');
-                $('.xblock-student_view[data-usage-id="'+usageId+'"]').removeClass('fullscreen_scormxblock_view');
+                iframe.removeClass('fullscreen_scormxblock_view');
 
                 iframe.addClass('hidden');
                 iframe.css('height', '0px');
@@ -49,7 +49,7 @@
             $('.launch-button').click(function() {
                 let iframe = $('.xblock-student_view[data-usage-id="'+usageId+'"] #scorm-object-frame');
                 $('.xblock-student_view[data-usage-id="'+usageId+'"] .launch-div').addClass('hidden');
-                $('.xblock-student_view[data-usage-id="'+usageId+'"]').addClass('fullscreen_scormxblock_view');
+                iframe.addClass('fullscreen_scormxblock_view');
                 $('.xblock-student_view[data-usage-id="'+usageId+'"] .exit-fullscreen-button').removeClass('hidden');
 
                 iframe.removeClass('hidden');

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -15,6 +15,12 @@
         let scormRuntimeInfo;
         var timerId;
 
+        function isInLMS(xblockElement) {
+            return $(xblockElement).closest('.xblock').hasClass('xblock-student_view');
+        }
+
+        let container = isInLMS(element) ? '.xblock-student_view' : '.xblock-author_view';
+
         function quitFullscreen() {
             let iframe_container = $(container + '[data-usage-id="'+usageId+'"] .scorm_object_container');
             let iframe = $(container + '[data-usage-id="'+usageId+'"] #scorm-object-frame');
@@ -57,14 +63,9 @@
               $scormFrame.on('load', resetIframeSize)
             }
 
-            function isInLMS(xblockElement) {
-                return $(xblockElement).closest('.xblock').hasClass('xblock-student_view');
-            }
-
-            let container = isInLMS(element) ? '.xblock-student_view' : '.xblock-author_view';
-            let launch_button_selector = container + '[data-usage-id="'+usageId+'"] .launch-button';
-
             $('.exit-fullscreen-button').click(quitFullscreen)
+
+            let launch_button_selector = container + '[data-usage-id="'+usageId+'"] .launch-button';
 
             $(launch_button_selector).click(function() {
                 let iframe_container = $(container + '[data-usage-id="'+usageId+'"] .scorm_object_container');

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -40,7 +40,7 @@
             let launch_button_selector = container + '[data-usage-id="'+usageId+'"] .launch-button';
 
             $('.exit-fullscreen-button').click(function() {
-                let iframe_container = $(container + '[data-usage-id="'+usageId+'"].scorm_object_container');
+                let iframe_container = $(container + '[data-usage-id="'+usageId+'"] .scorm_object_container');
                 let iframe = $(container + '[data-usage-id="'+usageId+'"] #scorm-object-frame');
                 $(container + '[data-usage-id="'+usageId+'"] .exit-fullscreen-button').addClass('hidden');
                 iframe_container.removeClass('fullscreen_scormxblock_view');
@@ -65,7 +65,7 @@
             })
 
             $(launch_button_selector).click(function() {
-                let iframe_container = $(container + '[data-usage-id="'+usageId+'"].scorm_object_container');
+                let iframe_container = $(container + '[data-usage-id="'+usageId+'"] .scorm_object_container');
                 let iframe = $(container + '[data-usage-id="'+usageId+'"] #scorm-object-frame');
 
                 if (!iframe_container.hasClass('fullscreen_scormxblock_view')) {

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -87,6 +87,12 @@
         }
 
         function GetValue(name) {
+            const value = getValueInRuntimeInfo(name)
+            if (value !== undefined) return value
+
+            const data = getPackageData();
+            data['name'] = name;
+
             fetch(getValueUrl, {
                 method: 'POST',
                 headers: {

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -40,25 +40,21 @@
                 iframe.addClass('hidden');
                 iframe.css('height', '0px');
 
-                $('.launch-button').removeClass('disabled');
-                $('.launch-before').toggleClass('hidden');
-                $('.launch-after').toggleClass('hidden');
             })
 
             $('.launch-button').click(function() {
                 let iframe = $('.xblock-student_view[data-usage-id="'+usageId+'"] #scorm-object-frame');
-                iframe.addClass('fullscreen_scormxblock_view');
-                $('.xblock-student_view[data-usage-id="'+usageId+'"] .exit-fullscreen-button').removeClass('hidden');
 
-                iframe.removeClass('hidden');
-                iframe.on('load', function() {
-                $(this).css('height', '100vh');
-                    iframe.css('height', '100vh');
-                });
+                if (!iframe.hasClass('fullscreen_scormxblock_view')) {
+                    iframe.addClass('fullscreen_scormxblock_view');
+                    $('.xblock-student_view[data-usage-id="'+usageId+'"] .exit-fullscreen-button').removeClass('hidden');
 
-                $('.launch-button').addClass('disabled');
-                $('.launch-before').toggleClass('hidden');
-                $('.launch-after').toggleClass('hidden');
+                    iframe.removeClass('hidden');
+                    iframe.on('load', function() {
+                    $(this).css('height', '100vh');
+                        iframe.css('height', '100vh');
+                    });
+                }
             })
 
             // Get runtime score value due to unexpected terminal action

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -518,10 +518,11 @@
                         window.loadedScormModules.push(element.dataset.usageId)
                         clearInterval(window.loadingScormModuleMap[element.dataset.usageId])
 
+                        // A SCORM pkg can have more than 1 <iframe>, we just setup event listener for the first one:
                         const keyEventTargetFrame = $iFrame.contentWindow.document.querySelector('iframe') || $iFrame;
                         keyEventTargetFrame.contentWindow.document.addEventListener('keyup', e => {
                             if (e.keyCode === 27 || e.key === 'Escape') {
-                                quitFullscreen()
+                                quitFullscreen();       // Quite full screen mode
                             }
                         })
                     }

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -34,7 +34,7 @@
             $('.launch-button').click(function() {
                 let usageId = element.dataset.usageId;
                 $('.xblock-student_view[data-usage-id="'+usageId+'"]').addClass('fullscreen_scormxblock_view');
-                $('.xblock-student_view[data-usage-id="'+usageId+'"] #scorm-object-frame').removeClass('hidden');
+                $('.xblock-student_view[data-usage-id="'+usageId+'"] #scorm-object-frame').css('height', '100%');;
                 $('.xblock-student_view[data-usage-id="'+usageId+'"] .launch-div').addClass('hidden');
 
                 $('.launch-button').addClass('disabled');

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -39,7 +39,7 @@
                 $('.xblock-student_view[data-usage-id="'+usageId+'"]').addClass('fullscreen_scormxblock_view');
 
                 iframe.removeClass('hidden');
-                $iframe.on('load', function() {
+                iframe.on('load', function() {
                 $(this).css('height', '100vh');
                     $('.xblock-student_view[data-usage-id="'+usageId+'"] #scorm-object-frame').css('height', '100vh');
                 });

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -20,10 +20,10 @@
         }
 
         let container = isInLMS(element) ? '.xblock-student_view' : '.xblock-author_view';
+        let iframe = $(container + '[data-usage-id="'+usageId+'"] #scorm-object-frame');
+        let iframe_container = $(container + '[data-usage-id="'+usageId+'"] .scorm_object_container');
 
         function quitFullscreen() {
-            let iframe_container = $(container + '[data-usage-id="'+usageId+'"] .scorm_object_container');
-            let iframe = $(container + '[data-usage-id="'+usageId+'"] #scorm-object-frame');
             iframe_container.removeClass('fullscreen_scormxblock_view');
 
             function updateQueryParam(url, key, value) {
@@ -44,7 +44,6 @@
         }
 
         function scormInit() {
-            let iframe = $(container + '[data-usage-id="'+usageId+'"] #scorm-object-frame');
             var ratios = {
                 '4:3': 0.75,
                 '16:9': 0.5625,
@@ -65,8 +64,6 @@
             let launch_button_selector = container + '[data-usage-id="'+usageId+'"] .launch-button';
 
             $(launch_button_selector).click(function() {
-                let iframe_container = $(container + '[data-usage-id="'+usageId+'"] .scorm_object_container');
-
                 if (!iframe_container.hasClass('fullscreen_scormxblock_view')) {
                     iframe_container.addClass('fullscreen_scormxblock_view');
                 }

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -33,10 +33,16 @@
 
             $('.launch-button').click(function() {
                 let usageId = element.dataset.usageId;
-                $('.xblock-student_view[data-usage-id="'+usageId+'"]').addClass('fullscreen_scormxblock_view');
-                $('.xblock-student_view[data-usage-id="'+usageId+'"] #scorm-object-frame').removeClass('hidden');
-                $('.xblock-student_view[data-usage-id="'+usageId+'"] #scorm-object-frame').css('height', '100%');
+
+                let iframe = $('.xblock-student_view[data-usage-id="'+usageId+'"] #scorm-object-frame');
                 $('.xblock-student_view[data-usage-id="'+usageId+'"] .launch-div').addClass('hidden');
+                $('.xblock-student_view[data-usage-id="'+usageId+'"]').addClass('fullscreen_scormxblock_view');
+
+                iframe.removeClass('hidden');
+                $iframe.on('load', function() {
+                $(this).css('height', '100vh');
+                    $('.xblock-student_view[data-usage-id="'+usageId+'"] #scorm-object-frame').css('height', '100vh');
+                });
 
                 $('.launch-button').addClass('disabled');
                 $('.launch-before').toggleClass('hidden');

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -91,6 +91,9 @@
                 type: "POST",
                 url: getValueUrl,
                 data: JSON.stringify(data),
+                headers: {
+                    'X-CSRFToken': GetCookie('csrftoken')
+                },
                 async: false
             });
             const content = JSON.parse(resp.responseText);
@@ -237,6 +240,9 @@
                     type: "POST",
                     url: commitUrl,
                     data: JSON.stringify(pendingValues),
+                    headers: {
+                        'X-CSRFToken': GetCookie('csrftoken')
+                    },
                     async: false,
                     success: function (response) {
                         if (typeof response['scorm_score_value'] !== "undefined") {
@@ -256,6 +262,9 @@
                     type: "POST",
                     url: enforce_commitUrl,
                     data: JSON.stringify(pendingValues),
+                    headers: {
+                        'X-CSRFToken': GetCookie('csrftoken')
+                    },
                     async: false,
                     success: function (response) {
                         if (typeof response['scorm_score_value'] !== "undefined") {
@@ -274,6 +283,9 @@
                 type: "POST",
                 url: commitUrl,
                 data: JSON.stringify(pendingValues),
+                headers: {
+                    'X-CSRFToken': GetCookie('csrftoken')
+                },
                 async: false,
                 success: function (response) {
                     if (typeof response['scorm_score_value'] !== "undefined") {
@@ -393,6 +405,9 @@
             const resp = $.ajax({
                 type: "GET",
                 url: runtime.handlerUrl(element, 'ping'),
+                headers: {
+                    'X-CSRFToken': GetCookie('csrftoken')
+                },
                 async: false
             });
             return resp.status === 200;
@@ -403,6 +418,9 @@
             $.ajax({
                 type: "GET",
                 url: syncScoreUrl,
+                headers: {
+                    'X-CSRFToken': GetCookie('csrftoken')
+                },
                 async: true,
                 success: function(response) {
                     $(".lesson_score", element).html(response['scorm_score_value']);

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -26,6 +26,8 @@
             let iframe = $(container + '[data-usage-id="'+usageId+'"] #scorm-object-frame');
             iframe_container.removeClass('fullscreen_scormxblock_view');
 
+            iframe.css('height', '');
+
             function updateQueryParam(url, key, value) {
                 var separator = url.indexOf('?') !== -1 ? '&' : '?';
                 var re = new RegExp('([?&])' + key + '=[^&]*');

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -253,12 +253,18 @@
             if (CheckSafariMobile()) {
                 const csrftoken = GetCookie('csrftoken');
                 pendingValues['csrfmiddlewaretoken'] = csrftoken;
+
                 var params = new URLSearchParams(pendingValues);
-                navigator.sendBeacon(ios_commitUrl, params);
-                setTimeout(function(){ syncScoreValue()},2000);
-                setTimeout(function(){ syncScoreValue()},5000);
-                setTimeout(function(){ syncScoreValue()},10000);
-                initPendingValues();
+                const success = navigator.sendBeacon(ios_commitUrl, params);
+
+                if (success) {
+                    setTimeout(function(){ syncScoreValue()},2000);
+                    setTimeout(function(){ syncScoreValue()},5000);
+                    setTimeout(function(){ syncScoreValue()},10000);
+
+                    initPendingValues();
+                }
+
                 return 'true';
             } else {
                 const csrftoken = GetCookie('csrftoken');
@@ -277,12 +283,15 @@
                     }
                   })
                   .then(function(data) {
+
+                    initPendingValues();
+
                     if (typeof data['scorm_score_value'] !== "undefined") {
                       $(".lesson_score", element).html(data['scorm_score_value']);
                     }
                     $(".success_status", element).html(data['scorm_status_value']);
                   });
-                initPendingValues();
+
                 return 'true';
             }
         }
@@ -308,6 +317,8 @@
                             });
                         }
 
+                        initPendingValues();
+
                         if (typeof content['scorm_score_value'] !== "undefined") {
                             $(".lesson_score", element).html(content['scorm_score_value']);
                         }
@@ -325,7 +336,6 @@
                     }
                 });
 
-                initPendingValues();
             }
             return 'true';
         }
@@ -351,6 +361,8 @@
                         });
                     }
 
+                    initPendingValues();
+
                     if (typeof content['scorm_score_value'] !== "undefined") {
                         $(".lesson_score", element).html(content['scorm_score_value']);
                     }
@@ -368,7 +380,6 @@
                 }
             });
 
-            initPendingValues();
             return 'true';
         }
 

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -92,13 +92,9 @@
             }).then(resp => resp.json().then(resp => {
                 if (resp.error) {
                     LearningTribes.Notification.Error({
-                        title: window.gettext("Internal Server Error"),
+                        title: window.gettext("We're having trouble saving your work"),
                         message: window.gettext(resp.error),
                     });
-
-                    setTimeout(function() {
-                        location.reload();
-                    }, 2000);
                 } else {
                     scormRuntimeInfo = resp.value
                 }
@@ -141,7 +137,7 @@
                     const content = response.json();
                     if(content.error) {
                         LearningTribes.Notification.Error({
-                            title: window.gettext("Internal Server Error"),
+                            title: window.gettext("We're having trouble saving your work"),
                             message: window.gettext(content.error),
                         });
                     } else {
@@ -149,8 +145,8 @@
                     }
                 } else if (response.status === 403) {
                     LearningTribes.Notification.Error({
-                        title: window.gettext("Internal Server Error"),
-                        message: window.gettext("Access Denied"),
+                        title: window.gettext("We're having trouble saving your work"),
+                        message: window.gettext("An error has occurred. Please try reloading the page."),
                     });
 
                 }
@@ -283,8 +279,8 @@
                 }).catch(function(error) {
                     if (!navigator.onLine || error.message.includes('Failed to fetch')) {
                         LearningTribes.Notification.Error({
-                            title: window.gettext("Internal Server Error"),
-                            message: window.gettext("Please check your network"),
+                            title: window.gettext("We're having trouble saving your work"),
+                            message: window.gettext("Please check your network connection."),
                         });
                     }
                 });
@@ -309,7 +305,7 @@
                         const content = response.json();
                         if(content.error) {
                             LearningTribes.Notification.Error({
-                                title: window.gettext("Internal Server Error"),
+                                title: window.gettext("We're having trouble saving your work"),
                                 message: window.gettext(content.error),
                             });
                         } else {
@@ -323,19 +319,15 @@
 
                     } else if (response.status === 403) {
                         LearningTribes.Notification.Error({
-                            title: window.gettext("Internal Server Error"),
-                            message: window.gettext("Access Denied"),
+                            title: window.gettext("We're having trouble saving your work"),
+                            message: window.gettext("An error has occurred. Please try reloading the page."),
                         });
-
-                        setTimeout(function() {
-                            location.reload();
-                        }, 2000);
                     }
                 }).catch(function(error) {
                     if (!navigator.onLine || error.message.includes('Failed to fetch')) {
                         LearningTribes.Notification.Error({
-                            title: window.gettext("Internal Server Error"),
-                            message: window.gettext("Please check your network"),
+                            title: window.gettext("We're having trouble saving your work"),
+                            message: window.gettext("Please check your network connection."),
                         });
                     }
                 });
@@ -360,7 +352,7 @@
                     const content = response.json();
                     if(content.error) {
                         LearningTribes.Notification.Error({
-                            title: window.gettext("Internal Server Error"),
+                            title: window.gettext("We're having trouble saving your work"),
                             message: window.gettext(content.error),
                         });
                     } else {
@@ -372,21 +364,17 @@
                     }
                     $(".success_status", element).html(content['scorm_status_value']);
 
-                } else if (response.status === 403) {   // Maybe it's a CSRF token error, we reload the page
+                } else if (response.status === 403) {   // Maybe it's a CSRF token error
                     LearningTribes.Notification.Error({
-                        title: window.gettext("Internal Server Error"),
-                        message: window.gettext("Access Denied"),
+                        title: window.gettext("We're having trouble saving your work"),
+                        message: window.gettext("An error has occurred. Please try reloading the page."),
                     });
-
-                    setTimeout(function() {
-                        location.reload();
-                    }, 2000);
                 }
             }).catch(function(error) {
                 if (!navigator.onLine || error.message.includes('Failed to fetch')) {
                     LearningTribes.Notification.Error({
-                        title: window.gettext("Internal Server Error"),
-                        message: window.gettext("Please check your network"),
+                        title: window.gettext("We're having trouble saving your work"),
+                        message: window.gettext("Please check your network connection."),
                     });
                 }
             });

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -289,6 +289,13 @@
                         $(".lesson_score", element).html(data['scorm_score_value']);
                     }
                     $(".success_status", element).html(data['scorm_status_value']);
+                }).catch(function(error) {
+                    if (!navigator.onLine || error.message.includes('Failed to fetch')) {
+                        LearningTribes.Notification.Error({
+                            title: window.gettext('Internal Server Error.'),
+                            message: window.gettext('Please check your network'),
+                        });
+                    }
                 });
 
                 return 'true';
@@ -333,6 +340,13 @@
                             location.reload();
                         }, 2000);
                     }
+                }).catch(function(error) {
+                    if (!navigator.onLine || error.message.includes('Failed to fetch')) {
+                        LearningTribes.Notification.Error({
+                            title: window.gettext('Internal Server Error.'),
+                            message: window.gettext('Please check your network'),
+                        });
+                    }
                 });
 
             }
@@ -376,6 +390,13 @@
                     setTimeout(function() {
                         location.reload();
                     }, 2000);
+                }
+            }).catch(function(error) {
+                if (!navigator.onLine || error.message.includes('Failed to fetch')) {
+                    LearningTribes.Notification.Error({
+                        title: window.gettext('Internal Server Error.'),
+                        message: window.gettext('Please check your network'),
+                    });
                 }
             });
 

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -44,20 +44,20 @@
         }
 
         function scormInit() {
-            var $scormFrame = $('#scorm-object-frame')
+            let iframe = $(container + '[data-usage-id="'+usageId+'"] #scorm-object-frame');
             var ratios = {
                 '4:3': 0.75,
                 '16:9': 0.5625,
                 '1:1': 1,
             }
             var resetIframeSize = function () {
-              $scormFrame.height($scormFrame.width() * ratios[ratio_value]);
+              iframe.height(iframe.width() * ratios[ratio_value]);
             }
-            if ($scormFrame.length){
+            if (iframe.length){
               $(window).resize(function () {
                 resetIframeSize();
               })
-              $scormFrame.on('load', resetIframeSize)
+              iframe.on('load', resetIframeSize)
             }
 
             $('.exit-fullscreen-button').click(quitFullscreen)
@@ -66,7 +66,6 @@
 
             $(launch_button_selector).click(function() {
                 let iframe_container = $(container + '[data-usage-id="'+usageId+'"] .scorm_object_container');
-                let iframe = $(container + '[data-usage-id="'+usageId+'"] #scorm-object-frame');
 
                 if (!iframe_container.hasClass('fullscreen_scormxblock_view')) {
                     iframe_container.addClass('fullscreen_scormxblock_view');

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -32,8 +32,13 @@
               $scormFrame.on('load', resetIframeSize)
             }
 
+            function isInLMS(xblockElement) {
+                return xblockElement.closest('.xblock').hasClass('xblock-student_view');
+            }
+
             $('.exit-fullscreen-button').click(function() {
-                let iframe = $('.xblock-student_view[data-usage-id="'+usageId+'"], .xblock-author_view[data-usage-id="'+usageId+'"] #scorm-object-frame');
+                let container = isInLMS(element) ? '.xblock-student_view' : '.xblock-author_view';
+                let iframe = $(container + '[data-usage-id="'+usageId+'"] #scorm-object-frame');
                 $('.xblock-student_view[data-usage-id="'+usageId+'"] .exit-fullscreen-button').addClass('hidden');
                 iframe.removeClass('fullscreen_scormxblock_view');
 
@@ -58,7 +63,8 @@
             })
 
             $('.launch-button').click(function() {
-                let iframe = $('.xblock-student_view[data-usage-id="'+usageId+'"], .xblock-author_view[data-usage-id="'+usageId+'"] #scorm-object-frame');
+                let container = isInLMS(element) ? '.xblock-student_view' : '.xblock-author_view';
+                let iframe = $(container + '[data-usage-id="'+usageId+'"] #scorm-object-frame');
 
                 if (!iframe.hasClass('fullscreen_scormxblock_view')) {
                     iframe.addClass('fullscreen_scormxblock_view');

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -162,9 +162,6 @@
                         message: window.gettext('Access Denied'),
                     });
 
-                    setTimeout(function() {
-                        location.reload();
-                    }, 2000);
                 }
             });
         }

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -303,7 +303,7 @@
         }
 
         function Enforce_Commit() {
-            if (('cmi.score.raw' in pendingValues && 'cmi.score.max' in pendingValues && 'cmi.score.min' in pendingValues) || ('cmi.core.score.raw' in pendingValues && 'cmi.core.score.max' in pendingValues && 'cmi.core.score.min' in pendingValues) || ('cmi.score.scaled' in pendingValues)) {
+            if (('cmi.score.raw' in pendingValues && 'cmi.score.max' in pendingValues && 'cmi.score.min' in pendingValues) || ('cmi.core.score.raw' in pendingValues && 'cmi.core.score.max' in pendingValues && 'cmi.core.score.min' in pendingValues) || ('cmi.core.lesson_status' in pendingValues)  || ('cmi.success_status' in pendingValues) || ('cmi.score.scaled' in pendingValues)) {
                 fetch(enforce_commitUrl, {
                     method: 'POST',
                     headers: {

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -490,13 +490,6 @@
                 window.API_1484_11 = new SCORM_2004_API();
             })
 
-            $(document).on('keydown', function(e) {
-                 if (e.keyCode === 27 || e.key === 'Escape') {
-                     console.log('ESC pressed!');
-                     quitFullscreen();
-                 }
-            });
-
             if (!window.loadingScormModuleMap) {
                 window.loadingScormModuleMap = {}
             }
@@ -524,6 +517,13 @@
                     $iFrame.onload = function() {
                         window.loadedScormModules.push(element.dataset.usageId)
                         clearInterval(window.loadingScormModuleMap[element.dataset.usageId])
+
+                        const keyEventTargetFrame = $iFrame.contentWindow.document.querySelector('iframe') || $iFrame;
+                        keyEventTargetFrame.contentWindow.document.addEventListener('keyup', e => {
+                            if (e.keyCode === 27 || e.key === 'Escape') {
+                                quitFullscreen()
+                            }
+                        })
                     }
                 }
             })

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -121,9 +121,6 @@
         function Terminate(value) {
             Commit(value);
             clearInterval(timerId);
-
-            quitFullscreen();
-
             return 'true';
         }
 

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -271,7 +271,7 @@
                     method: 'POST',
                     headers: {
                       'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
-                      'X-CSRFToken': GetCookie('csrftoken');
+                      'X-CSRFToken': GetCookie('csrftoken')
                     },
                     body: JSON.stringify(pendingValues),
                     credentials: 'same-origin',
@@ -495,10 +495,6 @@
                     }
                 }
             })
-            // if (!open_new_tab) {
-            //     $('#scorm-object-frame')[0].contentWindow.onbeforeunload = function () {
-            //         Commit('value');
-            //     }
-            // }
+
         });
     }

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -94,7 +94,12 @@
                 headers: {
                     'X-CSRFToken': GetCookie('csrftoken')
                 },
-                async: false
+                async: false,
+                error: function (xhr) {
+                    if (xhr.status === 403) {
+                        alert('CSRF token missing or incorrect. Please refresh the page and try again.');
+                    }
+                }
             });
             const content = JSON.parse(resp.responseText);
             if(content.error) {
@@ -241,6 +246,11 @@
                             $(".lesson_score", element).html(response['scorm_score_value']);
                         }
                         $(".success_status", element).html(response['scorm_status_value']);
+                    },
+                    error: function (xhr) {
+                        if (xhr.status === 403) {
+                            alert('CSRF token missing or incorrect. Please refresh the page and try again.');
+                        }
                     }
                 });
                 initPendingValues();
@@ -262,6 +272,11 @@
                         $(".lesson_score", element).html(response['scorm_score_value']);
                     }
                     $(".success_status", element).html(response['scorm_status_value']);
+                },
+                error: function (xhr) {
+                    if (xhr.status === 403) {
+                        alert('CSRF token missing or incorrect. Please refresh the page and try again.');
+                    }
                 }
             });
             initPendingValues();
@@ -318,7 +333,6 @@
                 'package_version': package_version
             }
         }
-
 
         function pingServer() {
             const resp = $.ajax({

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -481,6 +481,13 @@
                 window.API_1484_11 = new SCORM_2004_API();
             })
 
+            document.addEventListener('keyup', function(e) {
+                if (e.keyCode === 27 || e.key === 'Escape') {
+                    console.log('ESC pressed!');
+                    quitFullscreen();
+                }
+            });
+
             if (!window.loadingScormModuleMap) {
                 window.loadingScormModuleMap = {}
             }

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -28,6 +28,22 @@
             iframe_container.removeClass('fullscreen_scormxblock_view');
 
             iframe.css('height', '0px');
+
+            function updateQueryParam(url, key, value) {
+                var separator = url.indexOf('?') !== -1 ? '&' : '?';
+                var re = new RegExp('([?&])' + key + '=[^&]*');
+                if (re.test(url)) {
+                    return url.replace(re, '$1' + key + '=' + encodeURIComponent(value));
+                } else {
+                    return url + separator + key + '=' + encodeURIComponent(value);
+                }
+            }
+            // For some SCORM pkgs, they show "Ending Text" after learner clicks on "Exit Button".
+            // So we refresh the iframe.src to reload the content before the learner clicks the "Launch Button" again.
+            let newURL = updateQueryParam(iframe[0].src, 'lt_refresh_time', new Date().getTime());
+            iframe[0].src = newURL;
+            iframe.attr('data-src', newURL);
+
         }
 
         function scormInit() {
@@ -59,10 +75,7 @@
                     iframe_container.addClass('fullscreen_scormxblock_view');
                     $(container + '[data-usage-id="'+usageId+'"] .scorm-object-header').removeClass('hidden');
 
-                    iframe.on('load', function() {
-                    $(this).css('height', '100vh');
-                        iframe.css('height', '100vh');
-                    });
+                    iframe.css('height', '100vh');
                 }
             })
 

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -101,7 +101,7 @@
             }).then(resp => resp.json().then(resp => {
                 if (resp.error) {
                     LearningTribes.Notification.Error({
-                        title: window.gettext('Internal Server Error.'),
+                        title: window.gettext("Internal Server Error"),
                         message: window.gettext(resp.error),
                     });
 
@@ -150,7 +150,7 @@
                     const content = response.json();
                     if(content.error) {
                         LearningTribes.Notification.Error({
-                            title: window.gettext('Internal Server Error.'),
+                            title: window.gettext("Internal Server Error"),
                             message: window.gettext(content.error),
                         });
                     } else {
@@ -158,8 +158,8 @@
                     }
                 } else if (response.status === 403) {
                     LearningTribes.Notification.Error({
-                        title: window.gettext('Internal Server Error.'),
-                        message: window.gettext('Access Denied'),
+                        title: window.gettext("Internal Server Error"),
+                        message: window.gettext("Access Denied"),
                     });
 
                 }
@@ -292,8 +292,8 @@
                 }).catch(function(error) {
                     if (!navigator.onLine || error.message.includes('Failed to fetch')) {
                         LearningTribes.Notification.Error({
-                            title: window.gettext('Internal Server Error.'),
-                            message: window.gettext('Please check your network'),
+                            title: window.gettext("Internal Server Error"),
+                            message: window.gettext("Please check your network"),
                         });
                     }
                 });
@@ -318,7 +318,7 @@
                         const content = response.json();
                         if(content.error) {
                             LearningTribes.Notification.Error({
-                                title: window.gettext('Internal Server Error.'),
+                                title: window.gettext("Internal Server Error"),
                                 message: window.gettext(content.error),
                             });
                         } else {
@@ -332,8 +332,8 @@
 
                     } else if (response.status === 403) {
                         LearningTribes.Notification.Error({
-                            title: window.gettext('Internal Server Error.'),
-                            message: window.gettext('Access Denied'),
+                            title: window.gettext("Internal Server Error"),
+                            message: window.gettext("Access Denied"),
                         });
 
                         setTimeout(function() {
@@ -343,8 +343,8 @@
                 }).catch(function(error) {
                     if (!navigator.onLine || error.message.includes('Failed to fetch')) {
                         LearningTribes.Notification.Error({
-                            title: window.gettext('Internal Server Error.'),
-                            message: window.gettext('Please check your network'),
+                            title: window.gettext("Internal Server Error"),
+                            message: window.gettext("Please check your network"),
                         });
                     }
                 });
@@ -369,7 +369,7 @@
                     const content = response.json();
                     if(content.error) {
                         LearningTribes.Notification.Error({
-                            title: window.gettext('Internal Server Error.'),
+                            title: window.gettext("Internal Server Error"),
                             message: window.gettext(content.error),
                         });
                     } else {
@@ -383,8 +383,8 @@
 
                 } else if (response.status === 403) {   // Maybe it's a CSRF token error, we reload the page
                     LearningTribes.Notification.Error({
-                        title: window.gettext('Internal Server Error.'),
-                        message: window.gettext('Access Denied'),
+                        title: window.gettext("Internal Server Error"),
+                        message: window.gettext("Access Denied"),
                     });
 
                     setTimeout(function() {
@@ -394,8 +394,8 @@
             }).catch(function(error) {
                 if (!navigator.onLine || error.message.includes('Failed to fetch')) {
                     LearningTribes.Notification.Error({
-                        title: window.gettext('Internal Server Error.'),
-                        message: window.gettext('Please check your network'),
+                        title: window.gettext("Internal Server Error"),
+                        message: window.gettext("Please check your network"),
                     });
                 }
             });

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -34,7 +34,8 @@
             $('.launch-button').click(function() {
                 let usageId = element.dataset.usageId;
                 $('.xblock-student_view[data-usage-id="'+usageId+'"]').addClass('fullscreen_scormxblock_view');
-                $('.xblock-student_view[data-usage-id="'+usageId+'"] #scorm-object-frame').css('height', '100%');;
+                $('.xblock-student_view[data-usage-id="'+usageId+'"] #scorm-object-frame').removeClass('hidden');
+                $('.xblock-student_view[data-usage-id="'+usageId+'"] #scorm-object-frame').css('height', '100%');
                 $('.xblock-student_view[data-usage-id="'+usageId+'"] .launch-div').addClass('hidden');
 
                 $('.launch-button').addClass('disabled');

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -367,7 +367,7 @@
                     }
                     $(".success_status", element).html(content['scorm_status_value']);
 
-                } else if (response.status === 403) {
+                } else if (response.status === 403) {   // Maybe it's a CSRF token error, we reload the page
                     LearningTribes.Notification.Error({
                         title: window.gettext('Internal Server Error.'),
                         message: window.gettext('Access Denied'),

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -24,10 +24,7 @@
         function quitFullscreen() {
             let iframe_container = $(container + '[data-usage-id="'+usageId+'"] .scorm_object_container');
             let iframe = $(container + '[data-usage-id="'+usageId+'"] #scorm-object-frame');
-            $(container + '[data-usage-id="'+usageId+'"] .scorm-object-header').addClass('hidden');
             iframe_container.removeClass('fullscreen_scormxblock_view');
-
-            iframe.css('height', '0px');
 
             function updateQueryParam(url, key, value) {
                 var separator = url.indexOf('?') !== -1 ? '&' : '?';
@@ -73,7 +70,6 @@
 
                 if (!iframe_container.hasClass('fullscreen_scormxblock_view')) {
                     iframe_container.addClass('fullscreen_scormxblock_view');
-                    $(container + '[data-usage-id="'+usageId+'"] .scorm-object-header').removeClass('hidden');
 
                     iframe.css('height', '100vh');
                 }

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -36,8 +36,10 @@
                 return $(xblockElement).closest('.xblock').hasClass('xblock-student_view');
             }
 
+            let container = isInLMS(element) ? '.xblock-student_view' : '.xblock-author_view';
+            let launch_button_selector = container + '[data-usage-id="'+usageId+'"] .launch-button';
+
             $('.exit-fullscreen-button').click(function() {
-                let container = isInLMS(element) ? '.xblock-student_view' : '.xblock-author_view';
                 let iframe = $(container + '[data-usage-id="'+usageId+'"] #scorm-object-frame');
                 $(container + '[data-usage-id="'+usageId+'"] .exit-fullscreen-button').addClass('hidden');
                 iframe.removeClass('fullscreen_scormxblock_view');
@@ -61,7 +63,7 @@
 
             })
 
-            $('.launch-button').click(function() {
+            $(launch_button_selector).click(function() {
                 let container = isInLMS(element) ? '.xblock-student_view' : '.xblock-author_view';
                 let iframe = $(container + '[data-usage-id="'+usageId+'"] #scorm-object-frame');
 

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -219,9 +219,7 @@
           if (!document.cookie) {
             return null;
           }
-          // const xsrfCookies = document.cookie.split(';')
-          //   .map(c => c.trim())
-          //   .filter(c => c.startsWith(name + '='));
+
           const xsrfCookies = document.cookie.split(';')
             .map(function(c) {
                 return c.trim();

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -103,7 +103,11 @@
                     LearningTribes.Notification.Error({
                         title: window.gettext('Internal Server Error.'),
                         message: window.gettext(resp.error),
-                    })
+                    });
+
+                    setTimeout(function() {
+                        location.reload();
+                    }, 2000);
                 } else {
                     scormRuntimeInfo = resp.value
                 }
@@ -145,15 +149,22 @@
                 if (response.ok) {
                     const content = response.json();
                     if(content.error) {
-                        alert(content.error);
+                        LearningTribes.Notification.Error({
+                            title: window.gettext('Internal Server Error.'),
+                            message: window.gettext(content.error),
+                        });
                     } else {
                         return content.value;
                     }
                 } else if (response.status === 403) {
                     LearningTribes.Notification.Error({
                         title: window.gettext('Internal Server Error.'),
-                        message: window.gettext('CSRF token missing or incorrect for GET request'),
-                    })
+                        message: window.gettext('Access Denied'),
+                    });
+
+                    setTimeout(function() {
+                        location.reload();
+                    }, 2000);
                 }
             });
         }
@@ -296,7 +307,10 @@
                     if (response.ok) {
                         const content = response.json();
                         if(content.error) {
-                            alert(content.error);
+                            LearningTribes.Notification.Error({
+                                title: window.gettext('Internal Server Error.'),
+                                message: window.gettext(content.error),
+                            });
                         }
 
                         if (typeof content['scorm_score_value'] !== "undefined") {
@@ -307,8 +321,12 @@
                     } else if (response.status === 403) {
                         LearningTribes.Notification.Error({
                             title: window.gettext('Internal Server Error.'),
-                            message: window.gettext('CSRF token missing or incorrect for GET request'),
-                        })
+                            message: window.gettext('Access Denied'),
+                        });
+
+                        setTimeout(function() {
+                            location.reload();
+                        }, 2000);
                     }
                 });
 
@@ -332,7 +350,10 @@
                 if (response.ok) {
                     const content = response.json();
                     if(content.error) {
-                        alert(content.error);
+                        LearningTribes.Notification.Error({
+                            title: window.gettext('Internal Server Error.'),
+                            message: window.gettext(content.error),
+                        });
                     }
 
                     if (typeof content['scorm_score_value'] !== "undefined") {
@@ -343,8 +364,12 @@
                 } else if (response.status === 403) {
                     LearningTribes.Notification.Error({
                         title: window.gettext('Internal Server Error.'),
-                        message: window.gettext('CSRF token missing or incorrect for GET request'),
-                    })
+                        message: window.gettext('Access Denied'),
+                    });
+
+                    setTimeout(function() {
+                        location.reload();
+                    }, 2000);
                 }
             });
 

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -32,6 +32,10 @@
             }
 
             $('.launch-button').click(function() {
+                let usageId = element.dataset.usageId;
+                $('.xblock-student_view[data-usage-id="'+usageId+'"]').addClass('fullscreen_scormxblock_view');
+                $('.xblock-student_view[data-usage-id="block-v1:edX+NCCV_0008+2025-10-10+type@scormxblock+block@0fbbe21b1eca4b05b15ac149be834296"] #scorm-object-frame').removeClass('hidden');
+
                 $('.launch-button').addClass('disabled');
                 $('.launch-before').toggleClass('hidden');
                 $('.launch-after').toggleClass('hidden');

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -33,7 +33,7 @@
             }
 
             $('.exit-fullscreen-button').click(function() {
-                let iframe = $('.xblock-student_view[data-usage-id="'+usageId+'"] #scorm-object-frame');
+                let iframe = $('.xblock-student_view[data-usage-id="'+usageId+'"], .xblock-author_view[data-usage-id="'+usageId+'"] #scorm-object-frame');
                 $('.xblock-student_view[data-usage-id="'+usageId+'"] .exit-fullscreen-button').addClass('hidden');
                 iframe.removeClass('fullscreen_scormxblock_view');
 
@@ -58,7 +58,7 @@
             })
 
             $('.launch-button').click(function() {
-                let iframe = $('.xblock-student_view[data-usage-id="'+usageId+'"] #scorm-object-frame');
+                let iframe = $('.xblock-student_view[data-usage-id="'+usageId+'"], .xblock-author_view[data-usage-id="'+usageId+'"] #scorm-object-frame');
 
                 if (!iframe.hasClass('fullscreen_scormxblock_view')) {
                     iframe.addClass('fullscreen_scormxblock_view');

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -28,22 +28,6 @@
             iframe_container.removeClass('fullscreen_scormxblock_view');
 
             iframe.css('height', '0px');
-
-            function updateQueryParam(url, key, value) {
-                var separator = url.indexOf('?') !== -1 ? '&' : '?';
-                var re = new RegExp('([?&])' + key + '=[^&]*');
-                if (re.test(url)) {
-                    return url.replace(re, '$1' + key + '=' + encodeURIComponent(value));
-                } else {
-                    return url + separator + key + '=' + encodeURIComponent(value);
-                }
-            }
-            // For some SCORM pkgs, they show "Ending Text" after learner clicks on "Exit Button".
-            // So we refresh the iframe.src to reload the content before the learner clicks the "Launch Button" again.
-            let newURL = updateQueryParam(iframe[0].src, 'lt_refresh_time', new Date().getTime());
-            iframe[0].src = newURL;
-            iframe.attr('data-src', newURL);
-
         }
 
         function scormInit() {

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -39,9 +39,9 @@
             $('.exit-fullscreen-button').click(function() {
                 let container = isInLMS(element) ? '.xblock-student_view' : '.xblock-author_view';
                 let iframe = $(container + '[data-usage-id="'+usageId+'"] #scorm-object-frame');
+                $(container + '[data-usage-id="'+usageId+'"] .exit-fullscreen-button').addClass('hidden');
                 iframe.removeClass('fullscreen_scormxblock_view');
 
-                iframe.addClass('hidden');
                 iframe.css('height', '0px');
 
                 function updateQueryParam(url, key, value) {
@@ -67,8 +67,8 @@
 
                 if (!iframe.hasClass('fullscreen_scormxblock_view')) {
                     iframe.addClass('fullscreen_scormxblock_view');
+                    $(container + '[data-usage-id="'+usageId+'"] .exit-fullscreen-button').removeClass('hidden');
 
-                    iframe.removeClass('hidden');
                     iframe.on('load', function() {
                     $(this).css('height', '100vh');
                         iframe.css('height', '100vh');

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -26,8 +26,6 @@
             let iframe = $(container + '[data-usage-id="'+usageId+'"] #scorm-object-frame');
             iframe_container.removeClass('fullscreen_scormxblock_view');
 
-            iframe.css('height', '');
-
             function updateQueryParam(url, key, value) {
                 var separator = url.indexOf('?') !== -1 ? '&' : '?';
                 var re = new RegExp('([?&])' + key + '=[^&]*');
@@ -72,8 +70,6 @@
 
                 if (!iframe_container.hasClass('fullscreen_scormxblock_view')) {
                     iframe_container.addClass('fullscreen_scormxblock_view');
-
-                    iframe.css('height', '100vh');
                 }
             })
 

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -490,6 +490,13 @@
                 window.API_1484_11 = new SCORM_2004_API();
             })
 
+            $(document).on('keydown', function(e) {
+                 if (e.keyCode === 27 || e.key === 'Escape') {
+                     console.log('ESC pressed!');
+                     quitFullscreen();
+                 }
+            });
+
             if (!window.loadingScormModuleMap) {
                 window.loadingScormModuleMap = {}
             }
@@ -520,13 +527,6 @@
                     }
                 }
             })
-
-            $(document).on('keydown', function(e) {
-                 if (e.key === 'Escape') {
-                     console.log('ESC pressed！');
-                     quitFullscreen();
-                 }
-            });
 
         });
     }

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -42,7 +42,7 @@
             $('.exit-fullscreen-button').click(function() {
                 let iframe_container = $(container + '[data-usage-id="'+usageId+'"] .scorm_object_container');
                 let iframe = $(container + '[data-usage-id="'+usageId+'"] #scorm-object-frame');
-                $(container + '[data-usage-id="'+usageId+'"] .exit-fullscreen-button').addClass('hidden');
+                $(container + '[data-usage-id="'+usageId+'"] .scorm-object-header').addClass('hidden');
                 iframe_container.removeClass('fullscreen_scormxblock_view');
 
                 iframe.css('height', '0px');
@@ -70,7 +70,7 @@
 
                 if (!iframe_container.hasClass('fullscreen_scormxblock_view')) {
                     iframe_container.addClass('fullscreen_scormxblock_view');
-                    $(container + '[data-usage-id="'+usageId+'"] .exit-fullscreen-button').removeClass('hidden');
+                    $(container + '[data-usage-id="'+usageId+'"] .scorm-object-header').removeClass('hidden');
 
                     iframe.on('load', function() {
                     $(this).css('height', '100vh');

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -33,7 +33,7 @@
             }
 
             function isInLMS(xblockElement) {
-                return xblockElement.closest('.xblock').hasClass('xblock-student_view');
+                return $(xblockElement).closest('.xblock').hasClass('xblock-student_view');
             }
 
             $('.exit-fullscreen-button').click(function() {

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -35,7 +35,7 @@
                 let usageId = element.dataset.usageId;
                 $('.xblock-student_view[data-usage-id="'+usageId+'"]').addClass('fullscreen_scormxblock_view');
                 $('.xblock-student_view[data-usage-id="'+usageId+'"] #scorm-object-frame').removeClass('hidden');
-                $('.xblock-student_view[data-usage-id="'+usageId+'"] #id-scormxblock-launcher').addClass('hidden');
+                $('.xblock-student_view[data-usage-id="'+usageId+'"] .launch-div').addClass('hidden');
 
                 $('.launch-button').addClass('disabled');
                 $('.launch-before').toggleClass('hidden');

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -39,7 +39,7 @@
             $('.exit-fullscreen-button').click(function() {
                 let container = isInLMS(element) ? '.xblock-student_view' : '.xblock-author_view';
                 let iframe = $(container + '[data-usage-id="'+usageId+'"] #scorm-object-frame');
-                $('.xblock-student_view[data-usage-id="'+usageId+'"] .exit-fullscreen-button').addClass('hidden');
+                $(container + '[data-usage-id="'+usageId+'"] .exit-fullscreen-button').addClass('hidden');
                 iframe.removeClass('fullscreen_scormxblock_view');
 
                 iframe.addClass('hidden');
@@ -68,7 +68,7 @@
 
                 if (!iframe.hasClass('fullscreen_scormxblock_view')) {
                     iframe.addClass('fullscreen_scormxblock_view');
-                    $('.xblock-student_view[data-usage-id="'+usageId+'"] .exit-fullscreen-button').removeClass('hidden');
+                    $(container + '[data-usage-id="'+usageId+'"] .exit-fullscreen-button').removeClass('hidden');
 
                     iframe.removeClass('hidden');
                     iframe.on('load', function() {

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -460,11 +460,6 @@
             window.API = new SCORM_12_API();
             window.API_1484_11 = new SCORM_2004_API();
 
-            $('.launch-button', element).on('click', function() {
-                window.API = new SCORM_12_API();
-                window.API_1484_11 = new SCORM_2004_API();
-            })
-
             document.addEventListener('keyup', function(e) {
                 if (e.keyCode === 27 || e.key === 'Escape') {
                     console.log('ESC pressed!');

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -35,7 +35,7 @@
             $('.exit-fullscreen-button').click(function() {
                 let iframe = $('.xblock-student_view[data-usage-id="'+usageId+'"] #scorm-object-frame');
                 $('.xblock-student_view[data-usage-id="'+usageId+'"] .launch-div').removeClass('hidden');
-                $('.xblock-student_view[data-usage-id="'+usageId+'"] .exit-fullscreen-button').removeClass('hidden');
+                $('.xblock-student_view[data-usage-id="'+usageId+'"] .exit-fullscreen-button').addClass('hidden');
                 $('.xblock-student_view[data-usage-id="'+usageId+'"]').removeClass('fullscreen_scormxblock_view');
 
                 iframe.addClass('hidden');
@@ -50,6 +50,7 @@
                 let iframe = $('.xblock-student_view[data-usage-id="'+usageId+'"] #scorm-object-frame');
                 $('.xblock-student_view[data-usage-id="'+usageId+'"] .launch-div').addClass('hidden');
                 $('.xblock-student_view[data-usage-id="'+usageId+'"]').addClass('fullscreen_scormxblock_view');
+                $('.xblock-student_view[data-usage-id="'+usageId+'"] .exit-fullscreen-button').removeClass('hidden');
 
                 iframe.removeClass('hidden');
                 iframe.on('load', function() {

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -40,9 +40,10 @@
             let launch_button_selector = container + '[data-usage-id="'+usageId+'"] .launch-button';
 
             $('.exit-fullscreen-button').click(function() {
+                let iframe_container = $(container + '[data-usage-id="'+usageId+'"].scorm_object_container');
                 let iframe = $(container + '[data-usage-id="'+usageId+'"] #scorm-object-frame');
                 $(container + '[data-usage-id="'+usageId+'"] .exit-fullscreen-button').addClass('hidden');
-                iframe.removeClass('fullscreen_scormxblock_view');
+                iframe_container.removeClass('fullscreen_scormxblock_view');
 
                 iframe.css('height', '0px');
 
@@ -64,11 +65,11 @@
             })
 
             $(launch_button_selector).click(function() {
-                let container = isInLMS(element) ? '.xblock-student_view' : '.xblock-author_view';
+                let iframe_container = $(container + '[data-usage-id="'+usageId+'"].scorm_object_container');
                 let iframe = $(container + '[data-usage-id="'+usageId+'"] #scorm-object-frame');
 
-                if (!iframe.hasClass('fullscreen_scormxblock_view')) {
-                    iframe.addClass('fullscreen_scormxblock_view');
+                if (!iframe_container.hasClass('fullscreen_scormxblock_view')) {
+                    iframe_container.addClass('fullscreen_scormxblock_view');
                     $(container + '[data-usage-id="'+usageId+'"] .exit-fullscreen-button').removeClass('hidden');
 
                     iframe.on('load', function() {

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -82,30 +82,27 @@
         }
 
         function GetValue(name) {
-            const value = getValueInRuntimeInfo(name)
-            if (value !== undefined) return value
-
-            const data = getPackageData();
-            data['name'] = name;
-            const resp = $.ajax({
-                type: "POST",
-                url: getValueUrl,
-                data: JSON.stringify(data),
+            fetch(getValueUrl, {
+                method: 'POST',
                 headers: {
-                    'X-CSRFToken': GetCookie('csrftoken')
+                  'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+                  'X-CSRFToken': GetCookie('csrftoken')
                 },
-                async: false,
-                error: function (xhr) {
-                    if (xhr.status === 403) {
-                        alert('CSRF token missing or incorrect. Please refresh the page and try again.');
+                body: JSON.stringify(data),
+                credentials: 'same-origin',
+                keepalive: true
+            }).then(function(response) {
+                if (response.ok) {
+                    const content = response.json();
+                    if(content.error) {
+                        alert(content.error);
+                    } else {
+                        return content.value;
                     }
+                } else if (response.status === 403) {
+                    alert('CSRF token missing or incorrect for GET request');
                 }
             });
-            const content = JSON.parse(resp.responseText);
-            if(content.error) {
-                alert(content.error)
-            }
-            return content.value;
         }
 
         function SetValue(name, value) {
@@ -233,52 +230,65 @@
 
         function Enforce_Commit() {
             if (('cmi.score.raw' in pendingValues && 'cmi.score.max' in pendingValues && 'cmi.score.min' in pendingValues) || ('cmi.core.score.raw' in pendingValues && 'cmi.core.score.max' in pendingValues && 'cmi.core.score.min' in pendingValues) || ('cmi.score.scaled' in pendingValues)) {
-                $.ajax({
-                    type: "POST",
-                    url: enforce_commitUrl,
-                    data: JSON.stringify(pendingValues),
+                fetch(enforce_commitUrl, {
+                    method: 'POST',
                     headers: {
-                        'X-CSRFToken': GetCookie('csrftoken')
+                      'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+                      'X-CSRFToken': GetCookie('csrftoken')
                     },
-                    async: false,
-                    success: function (response) {
-                        if (typeof response['scorm_score_value'] !== "undefined") {
-                            $(".lesson_score", element).html(response['scorm_score_value']);
+                    body: JSON.stringify(pendingValues),
+                    credentials: 'same-origin',
+                    keepalive: true
+                }).then(function(response) {
+                    if (response.ok) {
+                        const content = response.json();
+                        if(content.error) {
+                            alert(content.error);
                         }
-                        $(".success_status", element).html(response['scorm_status_value']);
-                    },
-                    error: function (xhr) {
-                        if (xhr.status === 403) {
-                            alert('CSRF token missing or incorrect. Please refresh the page and try again.');
+
+                        if (typeof content['scorm_score_value'] !== "undefined") {
+                            $(".lesson_score", element).html(content['scorm_score_value']);
                         }
+                        $(".success_status", element).html(content['scorm_status_value']);
+
+                    } else if (response.status === 403) {
+                        alert('CSRF token missing or incorrect for GET request');
                     }
                 });
+
                 initPendingValues();
             }
             return 'true';
         }
 
         function Commit(value) {
-            $.ajax({
-                type: "POST",
-                url: commitUrl,
-                data: JSON.stringify(pendingValues),
+
+            fetch(commitUrl, {
+                method: 'POST',
                 headers: {
-                    'X-CSRFToken': GetCookie('csrftoken')
+                  'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+                  'X-CSRFToken': GetCookie('csrftoken')
                 },
-                async: false,
-                success: function (response) {
-                    if (typeof response['scorm_score_value'] !== "undefined") {
-                        $(".lesson_score", element).html(response['scorm_score_value']);
+                body: JSON.stringify(pendingValues),
+                credentials: 'same-origin',
+                keepalive: true
+            }).then(function(response) {
+                if (response.ok) {
+                    const content = response.json();
+                    if(content.error) {
+                        alert(content.error);
                     }
-                    $(".success_status", element).html(response['scorm_status_value']);
-                },
-                error: function (xhr) {
-                    if (xhr.status === 403) {
-                        alert('CSRF token missing or incorrect. Please refresh the page and try again.');
+
+                    if (typeof content['scorm_score_value'] !== "undefined") {
+                        $(".lesson_score", element).html(content['scorm_score_value']);
                     }
+                    $(".success_status", element).html(content['scorm_status_value']);
+
+                } else if (response.status === 403) {
+                    alert('CSRF token missing or incorrect for GET request');
                 }
             });
+
             initPendingValues();
             return 'true';
         }

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -15,6 +15,31 @@
         let scormRuntimeInfo;
         var timerId;
 
+        function quitFullscreen() {
+            let iframe_container = $(container + '[data-usage-id="'+usageId+'"] .scorm_object_container');
+            let iframe = $(container + '[data-usage-id="'+usageId+'"] #scorm-object-frame');
+            $(container + '[data-usage-id="'+usageId+'"] .scorm-object-header').addClass('hidden');
+            iframe_container.removeClass('fullscreen_scormxblock_view');
+
+            iframe.css('height', '0px');
+
+            function updateQueryParam(url, key, value) {
+                var separator = url.indexOf('?') !== -1 ? '&' : '?';
+                var re = new RegExp('([?&])' + key + '=[^&]*');
+                if (re.test(url)) {
+                    return url.replace(re, '$1' + key + '=' + encodeURIComponent(value));
+                } else {
+                    return url + separator + key + '=' + encodeURIComponent(value);
+                }
+            }
+            // For some SCORM pkgs, they show "Ending Text" after learner clicks on "Exit Button".
+            // So we refresh the iframe.src to reload the content before the learner clicks the "Launch Button" again.
+            let newURL = updateQueryParam(iframe[0].src, 'lt_refresh_time', new Date().getTime());
+            iframe[0].src = newURL;
+            iframe.attr('data-src', newURL);
+
+        }
+
         function scormInit() {
             var $scormFrame = $('#scorm-object-frame')
             var ratios = {
@@ -39,30 +64,7 @@
             let container = isInLMS(element) ? '.xblock-student_view' : '.xblock-author_view';
             let launch_button_selector = container + '[data-usage-id="'+usageId+'"] .launch-button';
 
-            $('.exit-fullscreen-button').click(function() {
-                let iframe_container = $(container + '[data-usage-id="'+usageId+'"] .scorm_object_container');
-                let iframe = $(container + '[data-usage-id="'+usageId+'"] #scorm-object-frame');
-                $(container + '[data-usage-id="'+usageId+'"] .scorm-object-header').addClass('hidden');
-                iframe_container.removeClass('fullscreen_scormxblock_view');
-
-                iframe.css('height', '0px');
-
-                function updateQueryParam(url, key, value) {
-                    var separator = url.indexOf('?') !== -1 ? '&' : '?';
-                    var re = new RegExp('([?&])' + key + '=[^&]*');
-                    if (re.test(url)) {
-                        return url.replace(re, '$1' + key + '=' + encodeURIComponent(value));
-                    } else {
-                        return url + separator + key + '=' + encodeURIComponent(value);
-                    }
-                }
-                // For some SCORM pkgs, they show "Ending Text" after learner clicks on "Exit Button".
-                // So we refresh the iframe.src to reload the content before the learner clicks the "Launch Button" again.
-                let newURL = updateQueryParam(iframe[0].src, 'lt_refresh_time', new Date().getTime());
-                iframe[0].src = newURL;
-                iframe.attr('data-src', newURL);
-
-            })
+            $('.exit-fullscreen-button').click(quitFullscreen)
 
             $(launch_button_selector).click(function() {
                 let iframe_container = $(container + '[data-usage-id="'+usageId+'"] .scorm_object_container');
@@ -85,7 +87,7 @@
             setTimeout(function(){ syncScoreValue()},5000);
             setTimeout(function(){ syncScoreValue()},10000);
 
-         }
+        }
 
         function syncScormRuntimeInfo () {
             if (scormRuntimeInfo) {
@@ -517,6 +519,13 @@
                     }
                 }
             })
+
+            $(document).on('keydown', function(e) {
+                 if (e.key === 'Escape') {
+                     console.log('ESC pressed！');
+                     quitFullscreen();
+                 }
+            });
 
         });
     }

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -25,7 +25,7 @@
 
         function quitFullscreen() {
             iframe_container.removeClass('fullscreen_scormxblock_view');
-
+/*
             function updateQueryParam(url, key, value) {
                 var separator = url.indexOf('?') !== -1 ? '&' : '?';
                 var re = new RegExp('([?&])' + key + '=[^&]*');
@@ -40,7 +40,7 @@
             let newURL = updateQueryParam(iframe[0].src, 'lt_refresh_time', new Date().getTime());
             iframe[0].src = newURL;
             iframe.attr('data-src', newURL);
-
+*/
         }
 
         function scormInit() {

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -39,6 +39,10 @@
 
                 iframe.addClass('hidden');
                 iframe.css('height', '0px');
+
+                $('.launch-button').removeClass('disabled');
+                $('.launch-before').toggleClass('hidden');
+                $('.launch-after').toggleClass('hidden');
             })
 
             $('.launch-button').click(function() {
@@ -52,6 +56,9 @@
                     iframe.css('height', '100vh');
                 });
 
+                $('.launch-button').addClass('disabled');
+                $('.launch-before').toggleClass('hidden');
+                $('.launch-after').toggleClass('hidden');
             })
 
             // Get runtime score value due to unexpected terminal action

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -35,6 +35,7 @@
                 let usageId = element.dataset.usageId;
                 $('.xblock-student_view[data-usage-id="'+usageId+'"]').addClass('fullscreen_scormxblock_view');
                 $('.xblock-student_view[data-usage-id="block-v1:edX+NCCV_0008+2025-10-10+type@scormxblock+block@0fbbe21b1eca4b05b15ac149be834296"] #scorm-object-frame').removeClass('hidden');
+                $('.xblock-student_view[data-usage-id="block-v1:edX+NCCV_0008+2025-10-10+type@scormxblock+block@0fbbe21b1eca4b05b15ac149be834296"] #id-scormxblock-launcher').addClass('hidden');
 
                 $('.launch-button').addClass('disabled');
                 $('.launch-before').toggleClass('hidden');

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -267,30 +267,29 @@
 
                 return 'true';
             } else {
-                const csrftoken = GetCookie('csrftoken');
                 fetch(commitUrl, {
                     method: 'POST',
                     headers: {
                       'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
-                      'X-CSRFToken': csrftoken
+                      'X-CSRFToken': GetCookie('csrftoken');
                     },
                     body: JSON.stringify(pendingValues),
                     credentials: 'same-origin',
                     keepalive: true
                 }).then(function(response) {
-                    if (response.ok) {
-                      return response.json();
-                    }
-                  })
-                  .then(function(data) {
+                      if (response.ok) {
+                          return response.json();
+                      }
 
+                })
+                .then(function(data) {
                     initPendingValues();
 
                     if (typeof data['scorm_score_value'] !== "undefined") {
-                      $(".lesson_score", element).html(data['scorm_score_value']);
+                        $(".lesson_score", element).html(data['scorm_score_value']);
                     }
                     $(".success_status", element).html(data['scorm_status_value']);
-                  });
+                });
 
                 return 'true';
             }
@@ -315,9 +314,9 @@
                                 title: window.gettext('Internal Server Error.'),
                                 message: window.gettext(content.error),
                             });
+                        } else {
+                            initPendingValues();
                         }
-
-                        initPendingValues();
 
                         if (typeof content['scorm_score_value'] !== "undefined") {
                             $(".lesson_score", element).html(content['scorm_score_value']);
@@ -359,9 +358,9 @@
                             title: window.gettext('Internal Server Error.'),
                             message: window.gettext(content.error),
                         });
+                    } else {
+                        initPendingValues();
                     }
-
-                    initPendingValues();
 
                     if (typeof content['scorm_score_value'] !== "undefined") {
                         $(".lesson_score", element).html(content['scorm_score_value']);
@@ -384,7 +383,7 @@
         }
 
         function initPendingValues(){
-            syncScormRuntimeInfo()
+            syncScormRuntimeInfo();
             pendingValues = getPackageData();
         }
 

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -39,7 +39,6 @@
             $('.exit-fullscreen-button').click(function() {
                 let container = isInLMS(element) ? '.xblock-student_view' : '.xblock-author_view';
                 let iframe = $(container + '[data-usage-id="'+usageId+'"] #scorm-object-frame');
-                $(container + '[data-usage-id="'+usageId+'"] .exit-fullscreen-button').addClass('hidden');
                 iframe.removeClass('fullscreen_scormxblock_view');
 
                 iframe.addClass('hidden');
@@ -68,7 +67,6 @@
 
                 if (!iframe.hasClass('fullscreen_scormxblock_view')) {
                     iframe.addClass('fullscreen_scormxblock_view');
-                    $(container + '[data-usage-id="'+usageId+'"] .exit-fullscreen-button').removeClass('hidden');
 
                     iframe.removeClass('hidden');
                     iframe.on('load', function() {

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -40,6 +40,21 @@
                 iframe.addClass('hidden');
                 iframe.css('height', '0px');
 
+                function updateQueryParam(url, key, value) {
+                    var separator = url.indexOf('?') !== -1 ? '&' : '?';
+                    var re = new RegExp('([?&])' + key + '=[^&]*');
+                    if (re.test(url)) {
+                        return url.replace(re, '$1' + key + '=' + encodeURIComponent(value));
+                    } else {
+                        return url + separator + key + '=' + encodeURIComponent(value);
+                    }
+                }
+                // For some SCORM pkgs, they show "Ending Text" after learner clicks on "Exit Button".
+                // So we refresh the iframe.src to reload the content before the learner clicks the "Launch Button" again.
+                let newURL = updateQueryParam(iframe[0].src, 'lt_refresh_time', new Date().getTime());
+                iframe[0].src = newURL;
+                iframe.attr('data-src', newURL);
+
             })
 
             $('.launch-button').click(function() {

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -189,43 +189,7 @@
         };
 
         function Extra_Commit() {
-            if (CheckChrome() || CheckSafari() && !CheckSafariMobile()) {
-                const csrftoken = GetCookie('csrftoken');
-                fetch(commitUrl, {
-                    method: 'POST',
-                    headers: {
-                      'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
-                      'X-CSRFToken': csrftoken
-                    },
-                    body: JSON.stringify(pendingValues),
-                    credentials: 'same-origin',
-                    keepalive: true
-                })
-                  // .then(response => {
-                  //   if (response.ok) {
-                  //     return response.json();
-                  //   }
-                  // })
-                  // .then(data => {
-                  //   if (typeof data['scorm_score_value'] !== "undefined") {
-                  //     $(".lesson_score", element).html(data['scorm_score_value']);
-                  //   }
-                  //   $(".success_status", element).html(data['scorm_status_value']);
-                  // });
-                  .then(function(response) {
-                    if (response.ok) {
-                      return response.json();
-                    }
-                  })
-                  .then(function(data) {
-                    if (typeof data['scorm_score_value'] !== "undefined") {
-                      $(".lesson_score", element).html(data['scorm_score_value']);
-                    }
-                    $(".success_status", element).html(data['scorm_status_value']);
-                  });
-                initPendingValues();
-                return 'true';
-            } else if (CheckSafariMobile()) {
+            if (CheckSafariMobile()) {
                 const csrftoken = GetCookie('csrftoken');
                 pendingValues['csrfmiddlewaretoken'] = csrftoken;
                 var params = new URLSearchParams(pendingValues);
@@ -236,21 +200,27 @@
                 initPendingValues();
                 return 'true';
             } else {
-                $.ajax({
-                    type: "POST",
-                    url: commitUrl,
-                    data: JSON.stringify(pendingValues),
+                const csrftoken = GetCookie('csrftoken');
+                fetch(commitUrl, {
+                    method: 'POST',
                     headers: {
-                        'X-CSRFToken': GetCookie('csrftoken')
+                      'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+                      'X-CSRFToken': csrftoken
                     },
-                    async: false,
-                    success: function (response) {
-                        if (typeof response['scorm_score_value'] !== "undefined") {
-                            $(".lesson_score", element).html(response['scorm_score_value']);
-                        }
-                        $(".success_status", element).html(response['scorm_status_value']);
+                    body: JSON.stringify(pendingValues),
+                    credentials: 'same-origin',
+                    keepalive: true
+                }).then(function(response) {
+                    if (response.ok) {
+                      return response.json();
                     }
-                });
+                  })
+                  .then(function(data) {
+                    if (typeof data['scorm_score_value'] !== "undefined") {
+                      $(".lesson_score", element).html(data['scorm_score_value']);
+                    }
+                    $(".success_status", element).html(data['scorm_status_value']);
+                  });
                 initPendingValues();
                 return 'true';
             }
@@ -296,57 +266,6 @@
             });
             initPendingValues();
             return 'true';
-            // if (CheckChrome() || CheckSafari() && !CheckSafariMobile()) {
-            //     const csrftoken = GetCookie('csrftoken');
-            //     fetch(commitUrl, {
-            //         method: 'POST',
-            //         headers: {
-            //           'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
-            //           'X-CSRFToken': csrftoken
-            //         },
-            //         body: JSON.stringify(pendingValues),
-            //         credentials: 'same-origin',
-            //         keepalive: true
-            //     })
-            //       .then(response => {
-            //         if (response.ok) {
-            //           return response.json();
-            //         }
-            //       })
-            //       .then(data => {
-            //         if (typeof data['scorm_score_value'] !== "undefined") {
-            //           $(".lesson_score", element).html(data['scorm_score_value']);
-            //         }
-            //         $(".success_status", element).html(data['scorm_status_value']);
-            //       });
-            //     initPendingValues();
-            //     return 'true';
-            // } else if (CheckSafariMobile()) {
-            //     const csrftoken = GetCookie('csrftoken');
-            //     pendingValues['csrfmiddlewaretoken'] = csrftoken;
-            //     var params = new URLSearchParams(pendingValues);
-            //     navigator.sendBeacon(ios_commitUrl, params);
-            //     setTimeout(function(){ syncScoreValue()},2000);
-            //     setTimeout(function(){ syncScoreValue()},5000);
-            //     setTimeout(function(){ syncScoreValue()},10000);
-            //     initPendingValues();
-            //     return 'true';
-            // } else {
-            //     $.ajax({
-            //         type: "POST",
-            //         url: commitUrl,
-            //         data: JSON.stringify(pendingValues),
-            //         async: false,
-            //         success: function (response) {
-            //             if (typeof response['scorm_score_value'] !== "undefined") {
-            //                 $(".lesson_score", element).html(response['scorm_score_value']);
-            //             }
-            //             $(".success_status", element).html(response['scorm_status_value']);
-            //         }
-            //     });
-            //     initPendingValues();
-            //     return 'true';
-            // }
         }
 
         function initPendingValues(){

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -100,7 +100,10 @@
                 body: JSON.stringify(getPackageData())
             }).then(resp => resp.json().then(resp => {
                 if (resp.error) {
-                    alert(resp.error)
+                    LearningTribes.Notification.Error({
+                        title: window.gettext('Internal Server Error.'),
+                        message: window.gettext(resp.error),
+                    })
                 } else {
                     scormRuntimeInfo = resp.value
                 }
@@ -147,7 +150,10 @@
                         return content.value;
                     }
                 } else if (response.status === 403) {
-                    alert('CSRF token missing or incorrect for GET request');
+                    LearningTribes.Notification.Error({
+                        title: window.gettext('Internal Server Error.'),
+                        message: window.gettext('CSRF token missing or incorrect for GET request'),
+                    })
                 }
             });
         }
@@ -299,7 +305,10 @@
                         $(".success_status", element).html(content['scorm_status_value']);
 
                     } else if (response.status === 403) {
-                        alert('CSRF token missing or incorrect for GET request');
+                        LearningTribes.Notification.Error({
+                            title: window.gettext('Internal Server Error.'),
+                            message: window.gettext('CSRF token missing or incorrect for GET request'),
+                        })
                     }
                 });
 
@@ -332,7 +341,10 @@
                     $(".success_status", element).html(content['scorm_status_value']);
 
                 } else if (response.status === 403) {
-                    alert('CSRF token missing or incorrect for GET request');
+                    LearningTribes.Notification.Error({
+                        title: window.gettext('Internal Server Error.'),
+                        message: window.gettext('CSRF token missing or incorrect for GET request'),
+                    })
                 }
             });
 

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -10,9 +10,10 @@
         const package_version = settings['scorm_pkg_version_value'];
         const package_date = settings['scorm_pkg_modified_value'];
         const ratio_value = settings['ratio_value'];
-        var timerId;
+        let usageId = element.dataset.usageId;
         let pendingValues = null;
-        let scormRuntimeInfo
+        let scormRuntimeInfo;
+        var timerId;
 
         function scormInit() {
             var $scormFrame = $('#scorm-object-frame')
@@ -31,9 +32,16 @@
               $scormFrame.on('load', resetIframeSize)
             }
 
-            $('.launch-button').click(function() {
-                let usageId = element.dataset.usageId;
+            $('.exit-fullscreen-button').click(function() {
+                let iframe = $('.xblock-student_view[data-usage-id="'+usageId+'"] #scorm-object-frame');
+                $('.xblock-student_view[data-usage-id="'+usageId+'"] .launch-div').removeClass('hidden');
+                $('.xblock-student_view[data-usage-id="'+usageId+'"]').removeClass('fullscreen_scormxblock_view');
 
+                iframe.addClass('hidden');
+                iframe.css('height', '0px');
+            })
+
+            $('.launch-button').click(function() {
                 let iframe = $('.xblock-student_view[data-usage-id="'+usageId+'"] #scorm-object-frame');
                 $('.xblock-student_view[data-usage-id="'+usageId+'"] .launch-div').addClass('hidden');
                 $('.xblock-student_view[data-usage-id="'+usageId+'"]').addClass('fullscreen_scormxblock_view');
@@ -41,7 +49,7 @@
                 iframe.removeClass('hidden');
                 iframe.on('load', function() {
                 $(this).css('height', '100vh');
-                    $('.xblock-student_view[data-usage-id="'+usageId+'"] #scorm-object-frame').css('height', '100vh');
+                    iframe.css('height', '100vh');
                 });
 
                 $('.launch-button').addClass('disabled');

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -34,8 +34,8 @@
             $('.launch-button').click(function() {
                 let usageId = element.dataset.usageId;
                 $('.xblock-student_view[data-usage-id="'+usageId+'"]').addClass('fullscreen_scormxblock_view');
-                $('.xblock-student_view[data-usage-id="block-v1:edX+NCCV_0008+2025-10-10+type@scormxblock+block@0fbbe21b1eca4b05b15ac149be834296"] #scorm-object-frame').removeClass('hidden');
-                $('.xblock-student_view[data-usage-id="block-v1:edX+NCCV_0008+2025-10-10+type@scormxblock+block@0fbbe21b1eca4b05b15ac149be834296"] #id-scormxblock-launcher').addClass('hidden');
+                $('.xblock-student_view[data-usage-id="'+usageId+'"] #scorm-object-frame').removeClass('hidden');
+                $('.xblock-student_view[data-usage-id="'+usageId+'"] #id-scormxblock-launcher').addClass('hidden');
 
                 $('.launch-button').addClass('disabled');
                 $('.launch-before').toggleClass('hidden');

--- a/scormxblock/static/js/src/scormxblock.js
+++ b/scormxblock/static/js/src/scormxblock.js
@@ -324,9 +324,6 @@
             const resp = $.ajax({
                 type: "GET",
                 url: runtime.handlerUrl(element, 'ping'),
-                headers: {
-                    'X-CSRFToken': GetCookie('csrftoken')
-                },
                 async: false
             });
             return resp.status === 200;
@@ -337,9 +334,6 @@
             $.ajax({
                 type: "GET",
                 url: syncScoreUrl,
-                headers: {
-                    'X-CSRFToken': GetCookie('csrftoken')
-                },
                 async: true,
                 success: function(response) {
                     $(".lesson_score", element).html(response['scorm_score_value']);


### PR DESCRIPTION
# Task
 - https://foundever.atlassian.net/browse/TRIB-1764

# Related PR
 - https://github.com/Learningtribes/triboo-theme/pull/834
 - https://github.com/Learningtribes/platform/pull/2204

# Issue Description
 - https://foundever.atlassian.net/browse/TRIB-1764?focusedCommentId=386104
```
Aug 27 22:26:17  - Forbidden (CSRF token missing or incorrect.): /courses/course-v1:Myacademysitel+V2+12152022/xblock/block-v1:Myacademysitel+V2+12152022+type@scormxblock+block@bb684e61681348d99e9c806ad9d547e3/handler/sync_runtime_info

Aug 27 22:26:17  - Forbidden (CSRF token missing or incorrect.): /courses/course-v1:Myacademysitel+V2+12152022/xblock/block-v1:Myacademysitel+V2+12152022+type@scormxblock+block@bb684e61681348d99e9c806ad9d547e3/handler/scorm_commit
......
```

# What we do
 - Support `Fullscreen` style instead of new tab feature
 - Notify the learners immediately if get access denied ( http 403 / csrf token error ) + Reload page
 - Support "Retry" for `cmi.core.score.raw` / `cmi.core.lesson_status` 
 - If network is disconnected, we prompt the learner to check the network
 - Moved "initPendingValues();" call to HTTP Success callback method

# Translations ❓ 
```
msgid "Access Denied"
msgid "Full screen"
msgid "Open in full screen"
msgid "Allow the module to open in full screen"
msgid "Please check your network"
msgid "Exit full screen"
msgid "We're having trouble saving your work"
msgid "Please check your network connection."
```

# How we deploy it
 - git pull Three PRs
 - compile JS / CSS
 - compile translations

# Script for updating the property "open_new_tab" of SCORM with value `True` 👇🏻:
 - Here is the SCRIPT 👉🏻  https://foundever.atlassian.net/browse/TRIB-1764?focusedCommentId=391486
 - I have tested it on Stage FR:
```
In [4]: from xmodule.modulestore.django import modulestore
   ...: store = modulestore()
   ...: courses = store.get_courses()
In [5]: for course in courses:
   ...:     course_key = course.id
   ...:     xblocks = store.get_items(course_key)
   ...:     scorm_xblocks = [b for b in xblocks if b.category == 'scormxblock']
   ...:     if scorm_xblocks:
   ...:         for seq, scorm in enumerate(scorm_xblocks, start=1):
   ...:             usage_id = scorm.scope_ids.usage_id
   ...:             if not scorm.open_new_tab:
   ...:                 print('{},{},{}, {},{}'.format(seq, course_key, usage_id, scorm.has_score, scorm.open_new_tab))
   ...:
5,course-v1:edX+NCCV_0008+2025-10-10,block-v1:edX+NCCV_0008+2025-10-10+type@scormxblock+block@3264255b9f544d148d0ff7c474ce7e6b, False,False
1,course-v1:edX+NCCV_0001+2025-10-10,block-v1:edX+NCCV_0001+2025-10-10+type@scormxblock+block@f93e50ff49134f74ae3e3bed65aa6f18, False,False
3,course-v1:edX+DemoX+Demo_Course,block-v1:edX+DemoX+Demo_Course+type@scormxblock+block@fa773669d7c646db9d8143ad0771e0bb, True,False

In [6]:

###### Ran this SCRIPT and test again as follow :    ######

In [7]: for course in courses:
   ...:     course_key = course.id
   ...:     xblocks = store.get_items(course_key)
   ...:     scorm_xblocks = [b for b in xblocks if b.category == 'scormxblock']
   ...:     if scorm_xblocks:
   ...:         for seq, scorm in enumerate(scorm_xblocks, start=1):
   ...:             usage_id = scorm.scope_ids.usage_id
   ...:             if not scorm.open_new_tab:
   ...:                 print('{},{},{}, {},{}'.format(seq, course_key, usage_id, scorm.has_score, scorm.open_new_tab))
   ...:

In [8]:


```


# Tested on Stage FR
 - 👉🏻  [Demo Course](https://stage-fr.learning-tribes.com/courses/course-v1:edX+NCCV_0008+2025-10-10/courseware/367d693e8cba4e6ba6e39576ef816224/5e2ec29658694e42b369124c21c4463a/) : 
    - [Studio Demo](https://studio-stage-fr.learning-tribes.com/container/block-v1:edX+NCCV_0008+2025-10-10+type@vertical+block@b8381f9e381349119f33fdca25fa6f92)
<img width="1295" height="774" alt="image" src="https://github.com/user-attachments/assets/eb9e5544-d5f6-4f8d-ac68-92ce9b00b040" />
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/7dfbcc99-3fcb-4f13-9746-683cf576c9b9" />
<img width="1399" height="868" alt="image" src="https://github.com/user-attachments/assets/818d9af5-eb31-4a0c-b226-810a927cbc7d" />