### PR TITLE
fix: route SCORM completion through runtime.publish to respect masque…

### DIFF
--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -36,8 +36,7 @@ from zipfile import ZipFile
 from io import BytesIO
 from xblockutils.studio_editable import StudioEditableXBlockMixin
 from xblockutils.fields import File
-from completion import models
-from opaque_keys.edx.keys import CourseKey, UsageKey
+
 
 try:
     from contentstore.views.assets import update_course_run_asset
@@ -991,13 +990,12 @@ class ScormXBlock(StudioEditableXBlockMixin, ScorableXBlockMixin, XBlock):
                 log_data
             )
 
-            user_id = self.scope_ids.user_id
-            user_obj = User.objects.get(id=user_id)
-            course_key = CourseKey.from_string('{}'.format(self.course_id))
-            block_key = self.scope_ids.usage_id.to_deprecated_string()
-            blocks_to_complete = [(UsageKey.from_string(block_key), 1.0)]
-
-            models.BlockCompletion.objects.submit_batch_completion(user_obj, course_key, blocks_to_complete)
+            # Use runtime.publish so the completion event passes through the LMS
+            # masquerade guard (module_render.py:522). The previous direct call to
+            # BlockCompletion.objects.submit_batch_completion() bypassed that guard and
+            # wrote a real BlockCompletion record for the student when an admin used
+            # "View as" masquerade, causing completion_date without a grade.
+            self.runtime.publish(self, 'completion', {'completion': 1.0})
 
             self.scorm_status = info['status']
 


### PR DESCRIPTION
# Related Task

- https://foundever.atlassian.net/browse/TRIB-1942

## Summary

Fix a platform bug where an admin using "View as" masquerade could accidentally
write a real `BlockCompletion` record for a student, resulting in
`completion_date` being set but `percent_grade = 0` ("Unsuccessful").

## Root Cause

`update_scorm_status()` previously called
`BlockCompletion.objects.submit_batch_completion()` as a **direct MySQL write**,
bypassing the LMS masquerade guard in `module_render.py:522`:

```python
# module_render.py:522 — blocks grade/completion events during masquerade
if handle_event and not is_masquerading_as_specific_student(user, course_id):
    handle_event(block, event)
```

Grade publishing (`_publish_grade`) correctly goes through `runtime.publish('grade')`
and was blocked. But the completion write was not — so the student received a
`BlockCompletion` record with no corresponding grade.

## Fix

Replace the direct call with `self.runtime.publish(self, 'completion', {'completion': 1.0})`,
routing the completion event through the standard LMS runtime path and inheriting
the existing masquerade guard automatically.

```python
# Before (7 lines, bypasses masquerade guard)
user_id = self.scope_ids.user_id
user_obj = User.objects.get(id=user_id)
course_key = CourseKey.from_string('{}'.format(self.course_id))
block_key = self.scope_ids.usage_id.to_deprecated_string()
blocks_to_complete = [(UsageKey.from_string(block_key), 1.0)]
models.BlockCompletion.objects.submit_batch_completion(user_obj, course_key, blocks_to_complete)

# After (1 line, respects masquerade guard)
self.runtime.publish(self, 'completion', {'completion': 1.0})
```

Also removes now-unused imports: `completion.models`, `opaque_keys.edx.keys.CourseKey/UsageKey`.

## Behavior Note

`runtime.publish('completion', ...)` writes the `BlockCompletion` record only when
the `completion.enable_completion_tracking` waffle switch is enabled. The previous
`submit_batch_completion()` call was unconditional. **Confirmed enabled on
production** (`ENABLE_COMPLETION_TRACKING: True`). This change aligns SCORM
completion with the standard XBlock completion contract used by video and
drag-and-drop blocks.

## Signal Path Comparison

| Path | Mechanism | During masquerade |
|------|-----------|-------------------|
| Grade (`_publish_grade`) | `runtime.publish('grade')` → `module_render.py:522` | Blocked ✅ |
| HTML block completion | `runtime.publish('completion')` → `module_render.py:522` | Blocked ✅ |
| SCORM completion (before) | `submit_batch_completion()` direct DB write | **Not blocked** ❌ |
| SCORM completion (after) | `runtime.publish('completion')` → `module_render.py:522` | Blocked ✅ |

## Testing

- Verify: admin masquerading as a student and completing SCORM no longer creates
  a `BlockCompletion` record for the real student
- Verify: a student completing SCORM normally still creates a `BlockCompletion`
  record and grade is published correctly